### PR TITLE
Fixed the wording in Classroom Assumptions Section Per Issue 121

### DIFF
--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -21,7 +21,7 @@ Settings can be assigned to certain users within Google Workspace through organi
 
 ## Assumptions
 
-This document assumes the organization is using GWS Enterprise Plus.
+This document assumes the organization is using GWS Education Plus.
 
 This document does not address, ensure compliance with, or supersede any law, regulation, or other authority.  Entities are responsible for complying with any recordkeeping, privacy, and other laws that may apply to the use of technology.  This document is not intended to, and does not, create any right or benefit for anyone against the United States, its departments, agencies, or entities, its officers, employees, or agents, or any other person.
 


### PR DESCRIPTION
## 🗣 Description ##

Changed the assumptions section in google classroom baseline from "Enterprise Plus" to "Education Plus" edition.

### 💭 Motivation and context

This change was required because of the Google Workspace edition that is needed to run certain functions for the clasroom baseline.

Fixes #121 
