### PR TITLE
Moved Wording from MEET3.1v0.1 Policy Statement to Rationale

### DIFF
--- a/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
@@ -118,10 +118,10 @@ Note: When this feature is not enabled, any attendee that is a member of the hos
 ### Policies
 
 #### GWS.MEET.3.1v0.1
-Host Management meeting features SHALL be enabled so that they are available by default when a host starts their meeting.
+Host Management meeting features SHALL be enabled.
 
 - Rationale
-  - Enabling these features does not pose any security risk and provides better collaboration features to users. If this setting was disabled then any participant could take control of the meeting.
+  - Enabling these features does not pose any security risk and provides better collaboration features to users. If this setting was disabled then any participant could take control of the meeting. They are available by default when a host starts their meeting.
 - Last Modified: July 3, 2023
 
 - MITRE ATT&CK TTP Mapping

--- a/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
@@ -121,7 +121,7 @@ Note: When this feature is not enabled, any attendee that is a member of the hos
 Host Management meeting features SHALL be enabled.
 
 - Rationale
-  - Enabling these features does not pose any security risk and provides better collaboration features to users. If this setting was disabled then any participant could take control of the meeting. They are available by default when a host starts their meeting.
+  - Enabling these features does not pose any security risk and provides better collaboration features to users. If this setting was disabled then any participant could take control of the meeting. When enabled, they are available by default when a host starts their meeting.
 - Last Modified: July 3, 2023
 
 - MITRE ATT&CK TTP Mapping

--- a/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Meet Minimum Viable Secure Configuration Baseline v0.1.md
@@ -122,7 +122,7 @@ Host Management meeting features SHALL be enabled.
 
 - Rationale
   - Enabling these features does not pose any security risk and provides better collaboration features to users. If this setting was disabled then any participant could take control of the meeting. When enabled, they are available by default when a host starts their meeting.
-- Last Modified: July 3, 2023
+- Last Modified: January 10, 2024
 
 - MITRE ATT&CK TTP Mapping
   - [T1562:001: Impair Defenses](https://attack.mitre.org/techniques/T1562/)


### PR DESCRIPTION
## 🗣 Description ##

Moved "so that they are available by default when a host starts their meeting." from the MEET.3.1v0.1 policy statement to the rationale section in order to keep the policy statement concise.

Fixes #125 
