### PR TITLE
Refactor All Rego

### DIFF
--- a/.github/workflows/run_opa_tests.yml
+++ b/.github/workflows/run_opa_tests.yml
@@ -32,3 +32,11 @@ jobs:
 
     - name: Run OPA Tests
       run: opa test rego/*.rego Testing/RegoTests/**/*.rego -v
+
+    - name: Setup Regal
+      uses: StyraInc/setup-regal@v0.2.0
+      with:
+        version: v0.11.0
+
+    - name: Run Regal Lint
+      run: regal lint --format github rego Testing

--- a/.github/workflows/run_opa_tests.yml
+++ b/.github/workflows/run_opa_tests.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Regal
       uses: StyraInc/setup-regal@v0.2.0
       with:
-        version: v0.11.0
+        version: v0.15.0
 
     - name: Run Regal Lint
       run: regal lint --format github rego Testing

--- a/.regal/config.yaml
+++ b/.regal/config.yaml
@@ -1,0 +1,60 @@
+# Regal linter configuration
+# All rules documented here:
+# https://docs.styra.com/regal/category/rules
+rules:
+  custom:
+    naming-convention:
+      # Codifying the conventions used in this project.
+      # By all means, change this to be less restrictive
+      # if you wish.
+      level: error
+      conventions:
+        - pattern: '^[A-Z]+[a-zA-Z0-9_]+$|^tests$|^test_|^check_'
+          targets:
+            - rule
+        - pattern: '^[A-Z]+[a-zA-Z0-9_]+$'
+          targets:
+            - function
+        - pattern: '^[a-z]+$'
+          targets:
+            - package
+  idiomatic:
+    no-defined-entrypoint:
+      # This is a good practice for documentation, and
+      # compilation to Wasm/IR, but not a requirement.
+      # Safe to ignore.
+      level: ignore
+  imports:
+    implicit-future-keywords:
+      # This rule is on it's way out anyway, as future
+      # versions of OPA will make these keywords standard.
+      level: ignore
+  style:
+    external-reference:
+      # This rule is quite opinionated / style preference
+      # safe to ignore.
+      level: ignore
+    file-length:
+      level: ignore
+    no-whitespace-comment:
+      # This repo is actually good about this, but frequently
+      # uses '#--' as a delimeter of sorts. That should be OK,
+      # and the next version of Regal will allow for exceptions
+      # like this: https://github.com/StyraInc/regal/issues/379
+      level: ignore
+    opa-fmt:
+      level: ignore
+    prefer-snake-case:
+      # This is the default style preference for Rego, but since
+      # the style of this project better matches the domain it is
+      # modeling, we'll ignore this rule in favor of the custom
+      # naming-convention rule defined above.
+      level: ignore
+    rule-length:
+      level: ignore
+    todo-comment:
+      level: ignore
+  testing:
+    test-outside-test-package:
+      # This is just a style preference
+      level: ignore

--- a/Testing/RegoTests/calendar/calendar01_test.rego
+++ b/Testing/RegoTests/calendar/calendar01_test.rego
@@ -389,7 +389,6 @@ test_ExtSharingPrimaryCal_Incorrect_V5 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    print(RuleOutput[0].ReportDetails)
     RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
     
 }

--- a/Testing/RegoTests/calendar/calendar01_test.rego
+++ b/Testing/RegoTests/calendar/calendar01_test.rego
@@ -26,7 +26,7 @@ test_ExtSharingPrimaryCal_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -66,7 +66,7 @@ test_ExtSharingPrimaryCal_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -106,7 +106,7 @@ test_ExtSharingPrimaryCal_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -157,7 +157,7 @@ test_ExtSharingPrimaryCal_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -208,7 +208,7 @@ test_ExtSharingPrimaryCal_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -237,11 +237,15 @@ test_ExtSharingPrimaryCal_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_ExtSharingPrimaryCal_Incorrect_V2 if {
@@ -266,7 +270,7 @@ test_ExtSharingPrimaryCal_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -306,7 +310,7 @@ test_ExtSharingPrimaryCal_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -314,7 +318,8 @@ test_ExtSharingPrimaryCal_Incorrect_V3 if {
 }
 
 test_ExtSharingPrimaryCal_Incorrect_V4 if {
-    # Test external sharing for primary calendars when there is no event for the Top-level OU but there is one for a different OU
+    # Test external sharing for primary calendars when there is no event for the Top-level OU
+    # but there is one for a different OU
     PolicyId := "GWS.CALENDAR.1.1v0.1"
     Output := tests with input as {
         "calendar_logs": {"items": [
@@ -335,15 +340,20 @@ test_ExtSharingPrimaryCal_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_ExtSharingPrimaryCal_Incorrect_V5 if {
-    # Test external sharing for primary calendars when the Top-Level OU is compliant, but a secondary OU is non-compliant
+    # Test external sharing for primary calendars when the Top-Level OU is compliant,
+    # but a secondary OU is non-compliant
     PolicyId := "GWS.CALENDAR.1.1v0.1"
     Output := tests with input as {
         "calendar_logs": {"items": [
@@ -375,7 +385,7 @@ test_ExtSharingPrimaryCal_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -399,7 +409,7 @@ test_External_Sharing_Options_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/calendar/calendar01_test.rego
+++ b/Testing/RegoTests/calendar/calendar01_test.rego
@@ -102,7 +102,7 @@ test_ExtSharingPrimaryCal_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -153,7 +153,7 @@ test_ExtSharingPrimaryCal_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -164,7 +164,7 @@ test_ExtSharingPrimaryCal_Correct_V4 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_ExtSharingPrimaryCal_Correct_V4 if {
+test_ExtSharingPrimaryCal_Correct_V5 if {
     # Test external sharing for primary, inherit from parent
     PolicyId := "GWS.CALENDAR.1.1v0.1"
     Output := tests with input as {
@@ -204,7 +204,7 @@ test_ExtSharingPrimaryCal_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 

--- a/Testing/RegoTests/calendar/calendar02_test.rego
+++ b/Testing/RegoTests/calendar/calendar02_test.rego
@@ -26,7 +26,7 @@ test_ExtInvitationsWarning_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -66,7 +66,7 @@ test_ExtInvitationsWarning_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -106,7 +106,7 @@ test_ExtInvitationsWarning_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -157,7 +157,7 @@ test_ExtInvitationsWarning_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -186,11 +186,15 @@ test_ExtInvitationsWarning_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_ExtInvitationsWarning_Incorrect_V2 if {
@@ -215,7 +219,7 @@ test_ExtInvitationsWarning_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -255,7 +259,7 @@ test_ExtInvitationsWarning_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -284,11 +288,15 @@ test_ExtInvitationsWarning_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_ExtInvitationsWarning_Incorrect_V5 if {
@@ -324,7 +332,7 @@ test_ExtInvitationsWarning_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/calendar/calendar02_test.rego
+++ b/Testing/RegoTests/calendar/calendar02_test.rego
@@ -102,7 +102,7 @@ test_ExtInvitationsWarning_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -153,7 +153,7 @@ test_ExtInvitationsWarning_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -338,5 +338,4 @@ test_ExtInvitationsWarning_Incorrect_V5 if {
     not RuleOutput[0].NoSuchEvent
     RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
 }
-
 #--

--- a/Testing/RegoTests/calendar/calendar03_test.rego
+++ b/Testing/RegoTests/calendar/calendar03_test.rego
@@ -1,7 +1,6 @@
 package calendar
 import future.keywords
 
-
 #
 # Policy 1
 #--
@@ -27,11 +26,14 @@ test_ExtSharingSecondaryCal_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>Only free busy/information for secondary calendars </span> is shared outside Test Top-Level Domain"
+    RuleOutput[0].ReportDetails == concat("", [
+        "<span class=setting>Only free busy/information for secondary calendars </span>",
+        " is shared outside Test Top-Level Domain"
+    ])
 }
 
 test_ExtSharingSecondaryCal_Correct_V2 if {
@@ -67,11 +69,14 @@ test_ExtSharingSecondaryCal_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>Only free busy/information for secondary calendars </span> is shared outside Test Top-Level Domain"
+    RuleOutput[0].ReportDetails == concat("", [
+        "<span class=setting>Only free busy/information for secondary calendars </span> ",
+        "is shared outside Test Top-Level Domain"
+    ])
 }
 
 test_ExtSharingSecondaryCal_Incorrect_V1 if {
@@ -96,7 +101,7 @@ test_ExtSharingSecondaryCal_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -129,11 +134,14 @@ test_ExtSharingSecondaryCal_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>All information for secondary calendars </span> is shared outside Test Top-Level Domain but outsiders cannot change calendars."
+    RuleOutput[0].ReportDetails == concat("", [
+        "<span class=setting>All information for secondary calendars </span>",
+        " is shared outside Test Top-Level Domain but outsiders cannot change calendars."
+    ])
 }
 
 test_ExtSharingSecondaryCal_Incorrect_V3 if {
@@ -169,11 +177,14 @@ test_ExtSharingSecondaryCal_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>All information for secondary calendars </span> is shared outside Test Top-Level Domain but outsiders cannot change calendars."
+    RuleOutput[0].ReportDetails == concat("", [
+        "<span class=setting>All information for secondary calendars </span>",
+        " is shared outside Test Top-Level Domain but outsiders cannot change calendars."
+    ])
 }
 
 #
@@ -191,7 +202,7 @@ test_ExternalSharingOptions_Secondary__Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/calendar/calendar03_test.rego
+++ b/Testing/RegoTests/calendar/calendar03_test.rego
@@ -100,7 +100,11 @@ test_ExtSharingSecondaryCal_Incorrect_V1 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Sharing options for secondary calendars are set to the default value."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_ExtSharingSecondaryCal_Incorrect_V2 if {

--- a/Testing/RegoTests/calendar/calendar04_test.rego
+++ b/Testing/RegoTests/calendar/calendar04_test.rego
@@ -27,11 +27,12 @@ test_CalInteropMan_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>Calendar interop is not enabled </span> for Test Top-Level Domain"
+    RuleOutput[0].ReportDetails ==
+                                "<span class=setting>Calendar interop is not enabled </span> for Test Top-Level Domain"
 }
 
 test_CalInteropMan_Correct_V2 if {
@@ -67,11 +68,12 @@ test_CalInteropMan_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "<span class=setting>Calendar interop is not enabled </span> for Test Top-Level Domain"
+    RuleOutput[0].ReportDetails == 
+                                "<span class=setting>Calendar interop is not enabled </span> for Test Top-Level Domain"
 }
 
 test_CalInteropMan_Incorrect_V1 if {
@@ -96,7 +98,7 @@ test_CalInteropMan_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -129,7 +131,7 @@ test_CalInteropMan_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -169,7 +171,7 @@ test_CalInteropMan_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -192,7 +194,7 @@ test_OAuth_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/calendar/calendar04_test.rego
+++ b/Testing/RegoTests/calendar/calendar04_test.rego
@@ -100,7 +100,11 @@ test_CalInteropMan_Incorrect_V1 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Calendar Interop Management settings are set to the default value."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_CalInteropMan_Incorrect_V2 if {

--- a/Testing/RegoTests/calendar/calendar05_test.rego
+++ b/Testing/RegoTests/calendar/calendar05_test.rego
@@ -97,7 +97,7 @@ test_CalendarAppointmentSlot_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -261,7 +261,7 @@ test_CalendarAppointmentSlot_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/calendar/calendar05_test.rego
+++ b/Testing/RegoTests/calendar/calendar05_test.rego
@@ -25,7 +25,7 @@ test_CalendarAppointmentSlot_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_CalendarAppointmentSlot_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -101,7 +101,7 @@ test_CalendarAppointmentSlot_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -129,11 +129,15 @@ test_CalendarAppointmentSlot_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_CalendarAppointmentSlot_Incorrect_V2 if {
@@ -157,7 +161,7 @@ test_CalendarAppointmentSlot_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -195,7 +199,7 @@ test_CalendarAppointmentSlot_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -223,7 +227,7 @@ test_CalendarAppointmentSlot_Incorrect_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -261,7 +265,7 @@ test_CalendarAppointmentSlot_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat01_test.rego
+++ b/Testing/RegoTests/chat/chat01_test.rego
@@ -25,7 +25,7 @@ test_History_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_History_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -101,7 +101,7 @@ test_History_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -149,7 +149,7 @@ test_History_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -197,7 +197,7 @@ test_History_Correct_V5 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -226,11 +226,15 @@ test_History_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_History_Incorrect_V2 if {
@@ -254,7 +258,7 @@ test_History_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -292,7 +296,7 @@ test_History_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -320,11 +324,15 @@ test_History_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--
 
@@ -359,7 +367,7 @@ test_History_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -379,7 +387,10 @@ test_Change_History_Setting_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -391,7 +402,7 @@ test_Change_History_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -407,7 +418,10 @@ test_Change_History_Setting_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -417,7 +431,10 @@ test_Change_History_Setting_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -429,7 +446,7 @@ test_Change_History_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -445,7 +462,10 @@ test_Change_History_Setting_Correct_V3 if {
                 "id": {"time": "2020-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -456,7 +476,10 @@ test_Change_History_Setting_Correct_V3 if {
                 "events": [{
                     "name": "DELETE_APPLICATION_SETTING",
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
                 }]
@@ -465,7 +488,10 @@ test_Change_History_Setting_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
@@ -477,7 +503,7 @@ test_Change_History_Setting_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -506,11 +532,15 @@ test_Change_History_Setting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Change_History_Setting_Incorrect_V2 if {
@@ -522,7 +552,10 @@ test_Change_History_Setting_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -534,7 +567,7 @@ test_Change_History_Setting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -550,7 +583,10 @@ test_Change_History_Setting_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -560,7 +596,10 @@ test_Change_History_Setting_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -572,7 +611,7 @@ test_Change_History_Setting_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -589,7 +628,10 @@ test_Change_History_Setting_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -599,7 +641,10 @@ test_Change_History_Setting_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -611,7 +656,7 @@ test_Change_History_Setting_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -628,7 +673,10 @@ test_Change_History_Setting_Incorrect_V5 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "ChatArchivingProto allow_chat_archiving_setting_modification"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "ChatArchivingProto allow_chat_archiving_setting_modification"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -640,10 +688,14 @@ test_Change_History_Setting_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/chat/chat01_test.rego
+++ b/Testing/RegoTests/chat/chat01_test.rego
@@ -198,7 +198,6 @@ test_History_Correct_V5 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -504,7 +503,6 @@ test_Change_History_Setting_Correct_V3 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat01_test.rego
+++ b/Testing/RegoTests/chat/chat01_test.rego
@@ -97,7 +97,7 @@ test_History_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -145,7 +145,7 @@ test_History_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -193,7 +193,7 @@ test_History_Correct_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -499,7 +499,7 @@ test_Change_History_Setting_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -652,7 +652,7 @@ test_Change_History_Setting_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/chat/chat02_test.rego
+++ b/Testing/RegoTests/chat/chat02_test.rego
@@ -13,7 +13,10 @@ test_External_File_Sharing_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -25,7 +28,7 @@ test_External_File_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -33,7 +36,8 @@ test_External_File_Sharing_Correct_V1 if {
 }
 
 test_External_File_Sharing_Correct_V2 if {
-    # Test users are not allowed to share files externally when there's multiple events and the most most recent is correct
+    # Test users are not allowed to share files externally when there's multiple events
+    # and the most most recent is correct
     PolicyId := "GWS.CHAT.2.1v0.1"
     Output := tests with input as {
         "chat_logs": {"items": [
@@ -41,7 +45,10 @@ test_External_File_Sharing_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -51,7 +58,10 @@ test_External_File_Sharing_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "ALLOW_ALL_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -63,7 +73,7 @@ test_External_File_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -79,7 +89,10 @@ test_External_File_Sharing_Correct_V3 if {
                 "id": {"time": "2020-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -89,7 +102,10 @@ test_External_File_Sharing_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "ALLOW_ALL_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
@@ -100,7 +116,10 @@ test_External_File_Sharing_Correct_V3 if {
                 "events": [{
                     "name": "DELETE_APPLICATION_SETTING",
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
                 }]
@@ -111,7 +130,7 @@ test_External_File_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -139,11 +158,15 @@ test_External_File_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_File_Sharing_Incorrect_V2 if {
@@ -155,7 +178,10 @@ test_External_File_Sharing_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "ALLOW_ALL_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -167,7 +193,7 @@ test_External_File_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -183,7 +209,10 @@ test_External_File_Sharing_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "IMAGES_ONLY"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -195,7 +224,7 @@ test_External_File_Sharing_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -211,7 +240,10 @@ test_External_File_Sharing_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "ALLOW_ALL_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -221,7 +253,10 @@ test_External_File_Sharing_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                       {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -233,7 +268,7 @@ test_External_File_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -249,7 +284,10 @@ test_External_File_Sharing_Incorrect_V5 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "IMAGES_ONLY"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -259,7 +297,10 @@ test_External_File_Sharing_Incorrect_V5 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                       {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -271,7 +312,7 @@ test_External_File_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -287,7 +328,10 @@ test_External_File_Sharing_Incorrect_V6 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Some other OU"},
                     ]
@@ -299,11 +343,15 @@ test_External_File_Sharing_Incorrect_V6 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_File_Sharing_Incorrect_V7 if {
@@ -315,7 +363,10 @@ test_External_File_Sharing_Incorrect_V7 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "ALLOW_ALL_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Some other OU"},
                     ]
@@ -325,7 +376,10 @@ test_External_File_Sharing_Incorrect_V7 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+                        },
                         {"name": "NEW_VALUE", "value": "NO_FILES"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -337,7 +391,7 @@ test_External_File_Sharing_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat02_test.rego
+++ b/Testing/RegoTests/chat/chat02_test.rego
@@ -126,7 +126,7 @@ test_External_File_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 

--- a/Testing/RegoTests/chat/chat03_test.rego
+++ b/Testing/RegoTests/chat/chat03_test.rego
@@ -25,7 +25,7 @@ test_Space_History_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -53,7 +53,7 @@ test_Space_History_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -91,7 +91,7 @@ test_Space_History_Setting_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -129,7 +129,7 @@ test_Space_History_Setting_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -157,11 +157,15 @@ test_Space_History_Setting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Space_History_Setting_Incorrect_V2 if {
@@ -185,7 +189,7 @@ test_Space_History_Setting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -213,7 +217,7 @@ test_Space_History_Setting_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -251,7 +255,7 @@ test_Space_History_Setting_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -289,7 +293,7 @@ test_Space_History_Setting_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -317,11 +321,15 @@ test_Space_History_Setting_Incorrect_V6 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Space_History_Setting_Incorrect_V7 if {
@@ -355,7 +363,7 @@ test_Space_History_Setting_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat04_test.rego
+++ b/Testing/RegoTests/chat/chat04_test.rego
@@ -25,7 +25,7 @@ test_External_Chat_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_External_Chat_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -101,7 +101,7 @@ test_External_Chat_Setting_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -149,7 +149,7 @@ test_External_Chat_Setting_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -177,11 +177,15 @@ test_External_Chat_Setting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_Chat_Setting_Incorrect_V2 if {
@@ -205,7 +209,7 @@ test_External_Chat_Setting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -243,7 +247,7 @@ test_External_Chat_Setting_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -281,11 +285,15 @@ test_External_Chat_Setting_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_Chat_Setting_Incorrect_V5 if {
@@ -319,7 +327,7 @@ test_External_Chat_Setting_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -351,7 +359,7 @@ test_AllowListed_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -389,7 +397,7 @@ test_AllowListed_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -437,7 +445,7 @@ test_AllowListed_Setting_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -465,11 +473,15 @@ test_AllowListed_Setting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_AllowListed_Setting_Incorrect_V2 if {
@@ -493,7 +505,7 @@ test_AllowListed_Setting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -531,7 +543,7 @@ test_AllowListed_Setting_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -559,11 +571,15 @@ test_AllowListed_Setting_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_AllowListed_Setting_Incorrect_V5 if {
@@ -597,7 +613,7 @@ test_AllowListed_Setting_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat04_test.rego
+++ b/Testing/RegoTests/chat/chat04_test.rego
@@ -145,7 +145,7 @@ test_External_Chat_Setting_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -441,7 +441,7 @@ test_AllowListed_Setting_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 

--- a/Testing/RegoTests/chat/chat05_test.rego
+++ b/Testing/RegoTests/chat/chat05_test.rego
@@ -25,7 +25,7 @@ test_External_Chat_App_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_External_Chat_App_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,11 +92,15 @@ test_External_Chat_App_Setting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_Chat_App_Setting_Incorrect_V2 if {
@@ -120,7 +124,7 @@ test_External_Chat_App_Setting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -158,7 +162,7 @@ test_External_Chat_App_Setting_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -186,11 +190,15 @@ test_External_Chat_App_Setting_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_External_Chat_App_Setting_Incorrect_V5 if {
@@ -224,7 +232,7 @@ test_External_Chat_App_Setting_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/chat/chat06_test.rego
+++ b/Testing/RegoTests/chat/chat06_test.rego
@@ -16,7 +16,7 @@ test_FromList_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/classroom/classroom01_test.rego
+++ b/Testing/RegoTests/classroom/classroom01_test.rego
@@ -27,7 +27,7 @@ test_JoinClassroom_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -68,7 +68,7 @@ test_JoinClassroom_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -97,7 +97,7 @@ test_JoinClassroom_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -138,7 +138,7 @@ test_JoinClassroom_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -167,11 +167,15 @@ test_JoinClassroom_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--
 
@@ -202,7 +206,7 @@ test_WhichClasses_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -243,7 +247,7 @@ test_WhichClasses_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -272,7 +276,7 @@ test_WhichClasses_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -312,7 +316,7 @@ test_WhichClasses_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -341,9 +345,13 @@ test_WhichClasses_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/classroom/classroom02_test.rego
+++ b/Testing/RegoTests/classroom/classroom02_test.rego
@@ -27,7 +27,7 @@ test_APIAccess_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -68,7 +68,7 @@ test_APIAccess_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -106,7 +106,7 @@ test_APIAccess_Correct_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -154,7 +154,7 @@ test_APIAccess_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -183,7 +183,7 @@ test_APIAccess_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -224,7 +224,7 @@ test_APIAccess_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -254,11 +254,15 @@ test_APIAccess_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 test_APIAccess_Incorrect_V4 if {
     # Test allow API Access is disabled when there are multiple OU and a secondary OU is wrong
@@ -291,7 +295,7 @@ test_APIAccess_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -320,11 +324,15 @@ test_APIAccess_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_APIAccess_Incorrect_V6 if {
@@ -348,7 +356,7 @@ test_APIAccess_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -386,7 +394,7 @@ test_APIAccess_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -424,7 +432,7 @@ test_APIAccess_Incorrect_V8 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -453,10 +461,14 @@ test_APIAccess_Incorrect_V9 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/classroom/classroom02_test.rego
+++ b/Testing/RegoTests/classroom/classroom02_test.rego
@@ -102,7 +102,7 @@ test_APIAccess_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -150,7 +150,7 @@ test_APIAccess_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -291,7 +291,7 @@ test_APIAccess_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -428,7 +428,7 @@ test_APIAccess_Incorrect_V8 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/classroom/classroom03_test.rego
+++ b/Testing/RegoTests/classroom/classroom03_test.rego
@@ -27,7 +27,7 @@ test_CleverRosterDisabled_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -68,7 +68,7 @@ test_CleverRosterDisabled_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -106,7 +106,7 @@ test_CleverRosterDisabled_Correct_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -154,7 +154,7 @@ test_CleverRosterDisabled_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -183,7 +183,7 @@ test_CleverRosterDisabled_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -224,7 +224,7 @@ test_CleverRosterDisabled_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -254,11 +254,15 @@ test_CleverRosterDisabled_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 test_CleverRosterDisabled_Incorrect_V4 if {
     # Test allow Clever Roster is disabled when there are multiple OU and a secondary OU is wrong
@@ -291,7 +295,7 @@ test_CleverRosterDisabled_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -320,11 +324,15 @@ test_CleverRosterDisabled_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 
 test_CleverRosterDisabled_Incorrect_V6 if {
@@ -348,7 +356,7 @@ test_CleverRosterDisabled_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -386,7 +394,7 @@ test_CleverRosterDisabled_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -424,7 +432,7 @@ test_CleverRosterDisabled_Incorrect_V8 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -453,10 +461,14 @@ test_CleverRosterDisabled_Incorrect_V9 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/classroom/classroom03_test.rego
+++ b/Testing/RegoTests/classroom/classroom03_test.rego
@@ -102,7 +102,7 @@ test_CleverRosterDisabled_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -150,7 +150,7 @@ test_CleverRosterDisabled_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -291,7 +291,7 @@ test_CleverRosterDisabled_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -428,7 +428,7 @@ test_CleverRosterDisabled_Incorrect_V8 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/classroom/classroom04_test.rego
+++ b/Testing/RegoTests/classroom/classroom04_test.rego
@@ -27,7 +27,7 @@ test_UnenrollStudents_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -68,7 +68,7 @@ test_UnenrollStudents_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -106,7 +106,7 @@ test_UnenrollStudents_Correct_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -154,7 +154,7 @@ test_UnenrollStudents_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -183,7 +183,7 @@ test_UnenrollStudents_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -224,7 +224,7 @@ test_UnenrollStudents_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -254,11 +254,15 @@ test_UnenrollStudents_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 test_UnenrollStudents_Incorrect_V4 if {
     # Test allow only teachers can unenroll students when there are multiple OU and a secondary OU is wrong
@@ -291,7 +295,7 @@ test_UnenrollStudents_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -320,11 +324,15 @@ test_UnenrollStudents_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 
 test_UnenrollStudents_Incorrect_V6 if {
@@ -348,7 +356,7 @@ test_UnenrollStudents_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -386,7 +394,7 @@ test_UnenrollStudents_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -424,7 +432,7 @@ test_UnenrollStudents_Incorrect_V8 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -453,10 +461,14 @@ test_UnenrollStudents_Incorrect_V9 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/classroom/classroom04_test.rego
+++ b/Testing/RegoTests/classroom/classroom04_test.rego
@@ -102,7 +102,7 @@ test_UnenrollStudents_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -150,7 +150,7 @@ test_UnenrollStudents_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -291,7 +291,7 @@ test_UnenrollStudents_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -428,7 +428,7 @@ test_UnenrollStudents_Incorrect_V8 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/commoncontrols/commoncontrols03_test.rego
+++ b/Testing/RegoTests/commoncontrols/commoncontrols03_test.rego
@@ -250,7 +250,7 @@ test_SSO_Incorrect_V4 if {
         "is non-compliant; manual check recommended."
     ])}
 
-test_SSO_Incorrect_V4 if {
+test_SSO_Incorrect_V5 if {
     # Test multiple OUs
     PolicyId := "GWS.COMMONCONTROLS.3.1v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/commoncontrols/commoncontrols04_test.rego
+++ b/Testing/RegoTests/commoncontrols/commoncontrols04_test.rego
@@ -319,7 +319,7 @@ test_Limit_Incorrect_V4 if {
         "is non-compliant; manual check recommended."
     ])}
 
-test_Limit_Incorrect_V4 if {
+test_Limit_Incorrect_V5 if {
     # Test no relevant events in top-level OU
     PolicyId := "GWS.COMMONCONTROLS.4.1v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/commoncontrols/commoncontrols14_test.rego
+++ b/Testing/RegoTests/commoncontrols/commoncontrols14_test.rego
@@ -213,9 +213,9 @@ test_Individual_Correct_V5 if {
     RuleOutput := [Result | some Result in Output; 
             Result.PolicyId == PolicyId; 
             Result.Criticality == "Shall"] 
-             # Note the additional filter: this is because 
-        # there are actually two tests with the same requirement string for this one,
-        # as it has both a testable portion and a not-implementable portion
+            # Note the additional filter: this is because 
+            # there are actually two tests with the same requirement string for this one,
+            # as it has both a testable portion and a not-implementable portion
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive01_test.rego
+++ b/Testing/RegoTests/drive/drive01_test.rego
@@ -275,11 +275,12 @@ test_Sharing_Incorrect_V5 if {
         "is non-compliant; manual check recommended."
     ])
 }
+#--
 
 #
 # GWS.DRIVEDOCS.1.2v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_Receiving_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -307,7 +308,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_Receiving_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -345,7 +346,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_Receiving_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -383,7 +384,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_Receiving_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -415,7 +416,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_Receiving_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -443,7 +444,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_Receiving_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -481,7 +482,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_Receiving_Incorrect_V4 if {
     # Test sharing setting when there are multiple OUs, top OU is compliant but secondary isn't
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -519,7 +520,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_Receiving_Incorrect_V5 if {
     # Test sharing setting when top level OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.2v0.1"
     Output := tests with input as {
@@ -554,7 +555,7 @@ test_SharingChecker_Incorrect_V5 if {
 #
 # GWS.DRIVEDOCS.1.3v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_Warnings_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -582,7 +583,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_Warnings_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -620,7 +621,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_Warningsr_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -658,7 +659,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_Warnings_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -690,7 +691,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_Warnings_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -718,7 +719,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_Warningsr_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -756,7 +757,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_Warnings_Incorrect_V4 if {
     # Test sharing setting when Top OU is correct but not secondary OU
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -794,7 +795,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_Warnings_Incorrect_V5 if {
     # Test sharing setting when Top OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.3v0.1"
     Output := tests with input as {
@@ -829,7 +830,7 @@ test_SharingChecker_Incorrect_V5 if {
 #
 # GWS.DRIVEDOCS.1.4v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_NonGoogle_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -857,7 +858,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_NonGoogle_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -895,7 +896,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_NonGoogle_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -933,7 +934,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_NonGoogle_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -965,7 +966,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_NonGoogle_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -993,7 +994,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_NonGoogle_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -1031,7 +1032,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_NonGoogle_Incorrect_V4 if {
     # Test sharing setting when Top OU is correct but not secondary OU
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -1069,7 +1070,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_NonGoogle_Incorrect_V5 if {
     # Test sharing setting when Top OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.4v0.1"
     Output := tests with input as {
@@ -1104,7 +1105,7 @@ test_SharingChecker_Incorrect_V5 if {
 #
 # GWS.DRIVEDOCS.1.5v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_Link_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1132,7 +1133,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_Link_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1170,7 +1171,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_Link_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1208,7 +1209,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_Link_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1240,7 +1241,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_Link_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1268,7 +1269,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_Link_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1306,7 +1307,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_Link_Incorrect_V4 if {
     # Test sharing setting when Top OU is correct but not secondary OU
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1344,7 +1345,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_Link_Incorrect_V5 if {
     # Test sharing setting when Top OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.5v0.1"
     Output := tests with input as {
@@ -1375,10 +1376,11 @@ test_SharingChecker_Incorrect_V5 if {
         "is non-compliant; manual check recommended."
     ])
 }
+#--
+
 #
 # GWS.DRIVEDOCS.1.6v0.1
 #--
-
 test_SharingChecker_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.6v0.1"
@@ -1654,7 +1656,7 @@ test_SharingChecker_Incorrect_V5 if {
 #
 # GWS.DRIVEDOCS.1.7v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_CrossDomain_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1682,7 +1684,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_CrossDomain_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1720,7 +1722,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_CrossDomain_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1758,7 +1760,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_CrossDomain_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1790,7 +1792,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_CrossDomain_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1818,7 +1820,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_CrossDomain_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1856,7 +1858,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_CrossDomain_Incorrect_V4 if {
     # Test sharing setting when Top OU is correct but not secondary OU
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1894,7 +1896,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_CrossDomain_Incorrect_V5 if {
     # Test sharing setting when Top OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.7v0.1"
     Output := tests with input as {
@@ -1925,11 +1927,12 @@ test_SharingChecker_Incorrect_V5 if {
         "is non-compliant; manual check recommended."
     ])
 }
+#--
 
 #
 # GWS.DRIVEDOCS.1.8v0.1
 #--
-test_SharingChecker_Correct_V1 if {
+test_Default_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -1957,7 +1960,7 @@ test_SharingChecker_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V2 if {
+test_Default_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -1995,7 +1998,7 @@ test_SharingChecker_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Correct_V3 if {
+test_Default_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -2033,7 +2036,7 @@ test_SharingChecker_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SharingChecker_Incorrect_V1 if {
+test_Default_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -2065,7 +2068,7 @@ test_SharingChecker_Incorrect_V1 if {
     ])
 }
 
-test_SharingChecker_Incorrect_V2 if {
+test_Default_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -2093,7 +2096,7 @@ test_SharingChecker_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V3 if {
+test_Default_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -2131,7 +2134,7 @@ test_SharingChecker_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_SharingChecker_Incorrect_V4 if {
+test_Default_Incorrect_V4 if {
     # Test sharing setting when Top OU is correct but not secondary OU
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {
@@ -2169,7 +2172,7 @@ test_SharingChecker_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_SharingChecker_Incorrect_V5 if {
+test_Default_Incorrect_V5 if {
     # Test sharing setting when Top OU is not present
     PolicyId := "GWS.DRIVEDOCS.1.8v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/drive/drive01_test.rego
+++ b/Testing/RegoTests/drive/drive01_test.rego
@@ -25,7 +25,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -64,7 +64,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -130,12 +130,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -159,7 +163,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
@@ -198,7 +202,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -236,7 +240,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -264,12 +268,16 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -296,7 +304,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -335,7 +343,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -373,7 +381,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -401,12 +409,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -430,7 +442,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -468,7 +480,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -506,7 +518,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -534,11 +546,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -565,7 +581,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -604,7 +620,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -642,7 +658,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -670,12 +686,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -699,7 +719,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -737,7 +757,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -775,7 +795,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -803,11 +823,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -834,7 +858,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -873,7 +897,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -911,7 +935,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -939,12 +963,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -968,7 +996,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1006,7 +1034,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1044,7 +1072,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1072,11 +1100,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -1103,7 +1135,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -1142,7 +1174,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1180,7 +1212,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1208,12 +1240,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -1237,7 +1273,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1275,7 +1311,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1313,7 +1349,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1341,11 +1377,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #
 # GWS.DRIVEDOCS.1.6v0.1
@@ -1372,7 +1412,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -1411,7 +1451,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1449,7 +1489,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1477,12 +1517,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -1506,7 +1550,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1544,7 +1588,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1582,7 +1626,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1610,11 +1654,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -1641,7 +1689,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -1680,7 +1728,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1718,7 +1766,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1746,12 +1794,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -1775,7 +1827,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1813,7 +1865,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1851,7 +1903,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1879,11 +1931,15 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -1910,7 +1966,7 @@ test_SharingChecker_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -1949,7 +2005,7 @@ test_SharingChecker_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1987,7 +2043,7 @@ test_SharingChecker_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -2015,12 +2071,16 @@ test_SharingChecker_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_SharingChecker_Incorrect_V2 if {
@@ -2044,7 +2104,7 @@ test_SharingChecker_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -2082,7 +2142,7 @@ test_SharingChecker_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -2120,7 +2180,7 @@ test_SharingChecker_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -2148,9 +2208,13 @@ test_SharingChecker_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/drive/drive01_test.rego
+++ b/Testing/RegoTests/drive/drive01_test.rego
@@ -26,7 +26,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -131,7 +130,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -164,7 +162,6 @@ test_Sharing_Incorrect_V2 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -269,7 +266,6 @@ test_Sharing_Incorrect_V5 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -305,7 +301,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -410,7 +405,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -582,7 +576,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -687,7 +680,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -859,7 +851,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -964,7 +955,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -1136,7 +1126,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1241,7 +1230,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -1413,7 +1401,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1518,7 +1505,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -1690,7 +1676,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1795,7 +1780,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -1967,7 +1951,6 @@ test_SharingChecker_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -2072,7 +2055,6 @@ test_SharingChecker_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive01_test.rego
+++ b/Testing/RegoTests/drive/drive01_test.rego
@@ -98,7 +98,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -236,7 +236,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -377,7 +377,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -514,7 +514,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -654,7 +654,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -791,7 +791,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -931,7 +931,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1068,7 +1068,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1208,7 +1208,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1345,7 +1345,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1485,7 +1485,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1622,7 +1622,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1762,7 +1762,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1899,7 +1899,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -2039,7 +2039,7 @@ test_SharingChecker_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -2176,7 +2176,7 @@ test_SharingChecker_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/drive/drive02_test.rego
+++ b/Testing/RegoTests/drive/drive02_test.rego
@@ -567,7 +567,10 @@ test_Sharing_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -596,7 +599,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -606,7 +612,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -634,7 +643,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -644,7 +656,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
                     ]
@@ -705,7 +720,10 @@ test_Sharing_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -733,7 +751,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -743,7 +764,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -771,7 +795,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -781,7 +808,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -809,7 +839,10 @@ test_Sharing_Incorrect_V5 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -844,7 +877,10 @@ test_Sharing_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -873,7 +909,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -883,7 +922,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -911,7 +953,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -921,7 +966,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
                     ]
@@ -982,7 +1030,10 @@ test_Sharing_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -1010,7 +1061,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -1020,7 +1074,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -1048,7 +1105,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -1058,7 +1118,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -1086,7 +1149,10 @@ test_Sharing_Incorrect_V5 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Shared Drive Creation new_team_drive_restricts_direct_access"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Shared Drive Creation new_team_drive_restricts_direct_access"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]

--- a/Testing/RegoTests/drive/drive02_test.rego
+++ b/Testing/RegoTests/drive/drive02_test.rego
@@ -26,7 +26,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -131,7 +130,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -303,7 +301,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -408,7 +405,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -583,7 +579,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -700,7 +695,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -893,7 +887,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1010,7 +1003,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -1200,7 +1192,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1305,7 +1296,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive02_test.rego
+++ b/Testing/RegoTests/drive/drive02_test.rego
@@ -98,7 +98,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -235,7 +235,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -375,7 +375,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -512,7 +512,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -667,7 +667,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -819,7 +819,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -977,7 +977,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1129,7 +1129,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1272,7 +1272,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1409,7 +1409,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/drive/drive02_test.rego
+++ b/Testing/RegoTests/drive/drive02_test.rego
@@ -277,9 +277,9 @@ test_Sharing_Incorrect_V5 if {
 }
 
 #
-# Baseline 2.2 - Policy 2
+# GWS.DRIVEDOCS.2.2v0.1
 #--
-test_Sharing_Correct_V1 if {
+test_Managers_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -307,7 +307,7 @@ test_Sharing_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V2 if {
+test_Managers_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -345,7 +345,7 @@ test_Sharing_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V3 if {
+test_Managers_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -383,7 +383,7 @@ test_Sharing_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Incorrect_V1 if {
+test_Managers_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -415,7 +415,7 @@ test_Sharing_Incorrect_V1 if {
     ])
 }
 
-test_Sharing_Incorrect_V2 if {
+test_Managers_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -443,7 +443,7 @@ test_Sharing_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V3 if {
+test_Managers_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -481,7 +481,7 @@ test_Sharing_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V4 if {
+test_Managers_Incorrect_V4 if {
     # Test sharing setting when top OU is correct but secondary isn't
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -519,7 +519,7 @@ test_Sharing_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_Sharing_Incorrect_V5 if {
+test_Managers_Incorrect_V5 if {
     # Test sharing setting when top OU is missing
     PolicyId := "GWS.DRIVEDOCS.2.2v0.1"
     Output := tests with input as {
@@ -552,9 +552,9 @@ test_Sharing_Incorrect_V5 if {
 }
 
 #
-# Baseline 2.2 - Policy 3
+# GWS.DRIVEDOCS.2.3v0.1
 #--
-test_Sharing_Correct_V1 if {
+test_Outside_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -585,7 +585,7 @@ test_Sharing_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V2 if {
+test_Outside_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -629,7 +629,7 @@ test_Sharing_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V3 if {
+test_Outside_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -673,7 +673,7 @@ test_Sharing_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Incorrect_V1 if {
+test_Outside_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -705,7 +705,7 @@ test_Sharing_Incorrect_V1 if {
     ])
 }
 
-test_Sharing_Incorrect_V2 if {
+test_Outside_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -736,7 +736,7 @@ test_Sharing_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V3 if {
+test_Outside_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -780,7 +780,7 @@ test_Sharing_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V4 if {
+test_Outside_Incorrect_V4 if {
     # Test sharing setting when top OU is correct but secondary isn't
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -824,7 +824,7 @@ test_Sharing_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_Sharing_Incorrect_V5 if {
+test_Outside_Incorrect_V5 if {
     # Test sharing setting when top OU is missing
     PolicyId := "GWS.DRIVEDOCS.2.3v0.1"
     Output := tests with input as {
@@ -860,9 +860,9 @@ test_Sharing_Incorrect_V5 if {
 }
 
 #
-# Baseline 2.2 - Policy 4
+# GWS.DRIVEDOCS.2.4v0.1
 #--
-test_Sharing_Correct_V1 if {
+test_SharedDrive_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -893,7 +893,7 @@ test_Sharing_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V2 if {
+test_SharedDrive_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -937,7 +937,7 @@ test_Sharing_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V3 if {
+test_SharedDrive_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -981,7 +981,7 @@ test_Sharing_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Incorrect_V1 if {
+test_SharedDrive_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -1013,7 +1013,7 @@ test_Sharing_Incorrect_V1 if {
     ])
 }
 
-test_Sharing_Incorrect_V2 if {
+test_SharedDrive_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -1044,7 +1044,7 @@ test_Sharing_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V3 if {
+test_SharedDrive_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -1088,7 +1088,7 @@ test_Sharing_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V4 if {
+test_SharedDrive_Incorrect_V4 if {
     # Test sharing setting when top OU is correct but secondary isn't
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -1132,7 +1132,7 @@ test_Sharing_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_Sharing_Incorrect_V5 if {
+test_SharedDrive_Incorrect_V5 if {
     # Test sharing setting when top OU is missing
     PolicyId := "GWS.DRIVEDOCS.2.4v0.1"
     Output := tests with input as {
@@ -1168,9 +1168,9 @@ test_Sharing_Incorrect_V5 if {
 }
 
 #
-# Baseline 2.2 - Policy 5
+# GWS.DRIVEDOCS.2.5v0.1
 #--
-test_Sharing_Correct_V1 if {
+test_Viewers_Correct_V1 if {
     # Test sharing setting when there's only one event
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1198,7 +1198,7 @@ test_Sharing_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V2 if {
+test_Viewers_Correct_V2 if {
     # Test sharing setting when there's multiple events and the most most recent is correct
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1236,7 +1236,7 @@ test_Sharing_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Correct_V3 if {
+test_Viewers_Correct_V3 if {
     # Test sharing setting when there's multiple OUs
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1274,7 +1274,7 @@ test_Sharing_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_Sharing_Incorrect_V1 if {
+test_Viewers_Incorrect_V1 if {
     # Test sharing setting when there are no relevant events
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1306,7 +1306,7 @@ test_Sharing_Incorrect_V1 if {
     ])
 }
 
-test_Sharing_Incorrect_V2 if {
+test_Viewers_Incorrect_V2 if {
     # Test sharing setting when there's only one event and it's wrong
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1334,7 +1334,7 @@ test_Sharing_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V3 if {
+test_Viewers_Incorrect_V3 if {
     # Test sharing setting when there are multiple events and the most recent is wrong
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1372,7 +1372,7 @@ test_Sharing_Incorrect_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_Sharing_Incorrect_V4 if {
+test_Viewers_Incorrect_V4 if {
     # Test sharing setting when top OU is correct but secondary isn't
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {
@@ -1410,7 +1410,7 @@ test_Sharing_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_Sharing_Incorrect_V5 if {
+test_Viewers_Incorrect_V5 if {
     # Test sharing setting when top OU is missing
     PolicyId := "GWS.DRIVEDOCS.2.5v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/drive/drive02_test.rego
+++ b/Testing/RegoTests/drive/drive02_test.rego
@@ -25,7 +25,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -64,7 +64,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -130,12 +130,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -159,7 +163,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -197,7 +201,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -235,7 +239,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -263,11 +267,15 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -294,7 +302,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -333,7 +341,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -371,7 +379,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -399,12 +407,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -428,7 +440,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -466,7 +478,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -504,7 +516,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -532,11 +544,15 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -563,7 +579,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -602,7 +618,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -640,7 +656,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -668,12 +684,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -697,7 +717,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -735,7 +755,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -773,7 +793,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -801,11 +821,15 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -832,7 +856,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -871,7 +895,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -909,7 +933,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -937,12 +961,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -966,7 +994,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1004,7 +1032,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1042,7 +1070,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1070,11 +1098,15 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #
@@ -1101,7 +1133,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -1140,7 +1172,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1178,7 +1210,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1206,12 +1238,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -1235,7 +1271,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1273,7 +1309,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1311,7 +1347,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -1339,9 +1375,13 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/drive/drive03_test.rego
+++ b/Testing/RegoTests/drive/drive03_test.rego
@@ -153,7 +153,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -346,7 +346,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/drive/drive03_test.rego
+++ b/Testing/RegoTests/drive/drive03_test.rego
@@ -13,7 +13,10 @@ test_Sharing_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -35,7 +38,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0])
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -52,7 +55,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -72,7 +78,10 @@ test_Sharing_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -84,7 +93,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -100,7 +109,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -120,7 +132,10 @@ test_Sharing_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
                     ]
@@ -142,7 +157,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -170,12 +185,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -187,7 +206,10 @@ test_Sharing_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -210,7 +232,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -226,7 +248,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -246,7 +271,10 @@ test_Sharing_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:27.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -258,7 +286,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -274,7 +302,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -304,7 +335,10 @@ test_Sharing_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:27.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -316,7 +350,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
@@ -333,7 +367,10 @@ test_Sharing_Incorrect_V5 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Link Security Update Settings allow_less_secure_link_user_restore"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "Link Security Update Settings allow_less_secure_link_user_restore"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -355,9 +392,13 @@ test_Sharing_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/drive/drive03_test.rego
+++ b/Testing/RegoTests/drive/drive03_test.rego
@@ -39,7 +39,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0])
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -186,7 +185,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
@@ -351,7 +349,6 @@ test_Sharing_Incorrect_V4 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive04_test.rego
+++ b/Testing/RegoTests/drive/drive04_test.rego
@@ -26,7 +26,6 @@ test_Security_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -131,7 +130,6 @@ test_Security_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive04_test.rego
+++ b/Testing/RegoTests/drive/drive04_test.rego
@@ -25,7 +25,7 @@ test_Security_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -64,7 +64,7 @@ test_Security_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_Security_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -130,12 +130,16 @@ test_Security_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Security_Incorrect_V2 if {
@@ -159,7 +163,7 @@ test_Security_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -197,7 +201,7 @@ test_Security_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -235,7 +239,7 @@ test_Security_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -263,9 +267,13 @@ test_Security_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/drive/drive04_test.rego
+++ b/Testing/RegoTests/drive/drive04_test.rego
@@ -98,7 +98,7 @@ test_Security_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -235,7 +235,7 @@ test_Security_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/drive/drive05_test.rego
+++ b/Testing/RegoTests/drive/drive05_test.rego
@@ -98,7 +98,7 @@ test_Sharing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -235,7 +235,7 @@ test_Sharing_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/drive/drive05_test.rego
+++ b/Testing/RegoTests/drive/drive05_test.rego
@@ -25,7 +25,7 @@ test_Sharing_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
@@ -64,7 +64,7 @@ test_Sharing_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_Sharing_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -130,12 +130,16 @@ test_Sharing_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Sharing_Incorrect_V2 if {
@@ -159,7 +163,7 @@ test_Sharing_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -197,7 +201,7 @@ test_Sharing_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -235,7 +239,7 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -263,9 +267,13 @@ test_Sharing_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }

--- a/Testing/RegoTests/drive/drive05_test.rego
+++ b/Testing/RegoTests/drive/drive05_test.rego
@@ -244,7 +244,7 @@ test_Sharing_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
 }
 
-test_Sharing_Incorrect_V4 if {
+test_Sharing_Incorrect_V5 if {
     # Test sharing setting when top level OU is missing
     PolicyId := "GWS.DRIVEDOCS.5.1v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/drive/drive05_test.rego
+++ b/Testing/RegoTests/drive/drive05_test.rego
@@ -26,7 +26,6 @@ test_Sharing_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput[0].ReportDetails)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -131,7 +130,6 @@ test_Sharing_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive06_test.rego
+++ b/Testing/RegoTests/drive/drive06_test.rego
@@ -51,7 +51,7 @@ test_DriveFs_Setting_Correct_V1 if {
             },
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -167,7 +167,7 @@ test_DriveFs_Setting_Correct_V3 if {
             },
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -301,7 +301,7 @@ test_DriveFs_Setting_InCorrect_V2 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -379,7 +379,7 @@ test_DriveFs_Setting_InCorrect_V3 if {
             },
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 

--- a/Testing/RegoTests/drive/drive06_test.rego
+++ b/Testing/RegoTests/drive/drive06_test.rego
@@ -55,7 +55,7 @@ test_DriveFs_Setting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -103,7 +103,7 @@ test_DriveFs_Setting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -171,7 +171,7 @@ test_DriveFs_Setting_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -209,7 +209,7 @@ test_DriveFs_Setting_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -247,7 +247,7 @@ test_DriveFs_Setting_InCorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -305,7 +305,7 @@ test_DriveFs_Setting_InCorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -383,7 +383,7 @@ test_DriveFs_Setting_InCorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/drive/drive07_test.rego
+++ b/Testing/RegoTests/drive/drive07_test.rego
@@ -15,7 +15,7 @@ test_Rule_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/gmail/gmail01_test.rego
+++ b/Testing/RegoTests/gmail/gmail01_test.rego
@@ -98,7 +98,7 @@ test_MailDelegation_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -262,7 +262,7 @@ test_MailDelegation_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail05_test.rego
+++ b/Testing/RegoTests/gmail/gmail05_test.rego
@@ -127,7 +127,7 @@ test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -187,7 +187,7 @@ test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -381,7 +381,7 @@ test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -520,7 +520,7 @@ test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -570,7 +570,7 @@ test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -770,7 +770,7 @@ test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -894,7 +894,7 @@ test_AttachmentProtectionAnomalousAttachment_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -938,7 +938,7 @@ test_AttachmentProtectionAnomalousAttachment_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1120,7 +1120,7 @@ test_AttachmentProtectionAnomalousAttachment_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1243,7 +1243,7 @@ test_AttachmentProtectionFutureRecommendedSettings_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1287,7 +1287,7 @@ test_AttachmentProtectionFutureRecommendedSettings_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1469,7 +1469,7 @@ test_AttachmentProtectionFutureRecommendedSettings_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail05_test.rego
+++ b/Testing/RegoTests/gmail/gmail05_test.rego
@@ -2,143 +2,10 @@ package gmail
 import future.keywords
 
 #
-# GWS.GMAIL.5.2v0.1
+# GWS.GMAIL.5.1v0.1
 #--
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Correct_V1 if {
-    # Test Attachment Protections when there's only one event
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        }
-    }
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
-}
-
-test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V2 if {
-    # Test Attachment Protections when there's multiple events and the most recent is correct
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            },
-            {
-                "id": {"time": "2021-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "false"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        }
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
-}
-
-test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V3 if {
-    # Test Attachment Protections when there's correct events in multiple OUs
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            },
-            {
-                "id": {"time": "2022-12-21T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": "Test Top-Level OU"
-        }
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
-}
-
-test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Correct_V4 if {
+test_Encrypted_Correct_V1 if {
     # Test inheritance
     PolicyId := "GWS.GMAIL.5.1v0.1"
     Output := tests with input as {
@@ -198,123 +65,8 @@ test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Correct_V4 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V1 if {
-    # Test Attachment Protections when there are no relevant events
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {"name": "SETTING_NAME", "value": "Something else"},
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        }
-    }
 
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == concat("", [
-        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
-        "While we are unable to determine the state from the logs, the default setting ",
-        "is non-compliant; manual check recommended."
-    ])
-}
-
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V2 if {
-    # Test Attachment Protections when there's only one event and it's wrong
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "false"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        }
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
-}
-
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V3 if {
-    # Test Attachment Protections when there are multiple events and the most recent is wrong
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "false"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            },
-            {
-                "id": {"time": "2021-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        },
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
-}
-
-test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Incorrect_V4 if {
+test_Encrypted_Incorrect_V1 if {
     # Test Attachment Protections when there's only one event and it's wrong
     PolicyId := "GWS.GMAIL.5.1v0.1"
     Output := tests with input as {
@@ -346,7 +98,7 @@ test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Incorrect_V4 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
 }
 
-test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Incorrect_V5 if {
+test_Encrypted_Incorrect_V2 if {
     # Test Attachment Protections when there are multiple events and the most recent is wrong
     PolicyId := "GWS.GMAIL.5.1v0.1"
     Output := tests with input as {
@@ -393,11 +145,10 @@ test_AttachmentProtectionEncryptedAttachmentsUntrustedSenders_Incorrect_V5 if {
 }
 #--
 
-
 #
 # GWS.GMAIL.5.2v0.1
 #--
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Correct_V1 if {
+test_Scripts_Correct_V1 if {
     # Test Attachment Protections when there's only one event
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -431,7 +182,7 @@ test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Correct_V1 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V2 if {
+test_Scripts_Correct_V2 if {
     # Test Attachment Protections when there's multiple events and the most recent is correct
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -481,7 +232,7 @@ test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V3 if {
+test_Scripts_Correct_V3 if {
     # Test Attachment Protections when there's correct events in multiple OUs
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -531,57 +282,7 @@ test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_AttachmentProetectionAttachmentsScriptsUntrustedSenders_Correct_V4 if {
-    # Test Attachment Protections when there's correct events in multiple OUs
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            },
-            {
-                "id": {"time": "2022-12-21T00:02:28.672Z"},
-                "events": [{
-                    "name": "DELETE_APPLICATION_SETTING",
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": "Test Top-Level OU"
-        }
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
-}
-
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V1 if {
+test_Scripts_Incorrect_V1 if {
     # Test Attachment Protections when there are no relevant events
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -613,7 +314,7 @@ test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V1 if {
     ])
 }
 
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V2 if {
+test_Scripts_Incorrect_V2 if {
     # Test Attachment Protections when there's only one event and it's wrong
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -647,7 +348,7 @@ test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V3 if {
+test_Scripts_Incorrect_V3 if {
     # Test Attachment Protections when there are multiple events and the most recent is wrong
     PolicyId := "GWS.GMAIL.5.2v0.1"
     Output := tests with input as {
@@ -696,96 +397,11 @@ test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V3 if {
     not RuleOutput[0].NoSuchEvent
     RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
-
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V4 if {
-    # Test Attachment Protections when there's only one event and it's wrong
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "false"},
-                        {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": ""
-        }
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
-}
-
-test_AttachmentProtectionAttachmentsScriptsUntrustedSenders_Incorrect_V5 if {
-    # Test Attachment Protections when there are multiple events and the most recent is wrong
-    PolicyId := "GWS.GMAIL.5.2v0.1"
-    Output := tests with input as {
-        "gmail_logs": {"items": [
-            {
-                "id": {"time": "2022-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "false"},
-                        {"name": "ORG_UNIT_NAME", "value": "Secondary OU"},
-                    ]
-                }]
-            },
-            {
-                "id": {"time": "2021-12-20T00:02:28.672Z"},
-                "events": [{
-                    "parameters": [
-                        {
-                            "name": "SETTING_NAME",
-                            "value": concat("", [
-                                "Attachment safety Enable: protect against attachments with scripts from untrusted ",
-                                "senders"
-                            ])
-                        },
-                        {"name": "NEW_VALUE", "value": "true"},
-                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-                    ]
-                }]
-            }
-        ]},
-        "tenant_info": {
-            "topLevelOU": "Test Top-Level OU"
-        },
-    }
-
-    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    count(RuleOutput) == 1
-    not RuleOutput[0].RequirementMet
-    not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
-}
-
+#--
 
 #
 # GWS.GMAIL.5.3v0.1
 #--
-
 test_AttachmentProtectionAnomalousAttachment_Correct_V1 if {
     # Test Attachment Protections when there's only one event
     PolicyId := "GWS.GMAIL.5.3v0.1"

--- a/Testing/RegoTests/gmail/gmail06_test.rego
+++ b/Testing/RegoTests/gmail/gmail06_test.rego
@@ -113,7 +113,7 @@ test_LinksExternalImagesProtectionIdentifyLinksURL_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -157,7 +157,7 @@ test_LinksExternalImagesProtectionIdentifyLinksURL_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -339,7 +339,7 @@ test_LinksExternalImagesProtectionIdentifyLinksURL_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -463,7 +463,7 @@ test_LinksExternalImagesProtectionScanLinkedImages_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -615,7 +615,7 @@ test_LinksExternalImagesProtectionScanLinkedImages_Incorrect_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -753,7 +753,7 @@ test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V2 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -804,7 +804,7 @@ test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1004,7 +1004,7 @@ test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1142,7 +1142,7 @@ test_LinksExternalImagesProtectionFutureRecommendedSettings_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1192,7 +1192,7 @@ test_LinksExternalImagesProtectionFutureRecommendedSettings_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1342,7 +1342,7 @@ test_LinksExternalImagesProtectionFutureRecommendedSettings_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail06_test.rego
+++ b/Testing/RegoTests/gmail/gmail06_test.rego
@@ -714,7 +714,7 @@ test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V2 if {
+test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V3 if {
     # Test Links and External Images Protections when there's multiple events and the most recent is correct
     PolicyId := "GWS.GMAIL.6.3v0.1"
     Output := tests with input as {
@@ -765,7 +765,7 @@ test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V2 if {
 }
 
 
-test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V3 if {
+test_LinksExternalImagesProtectionWarningLinksUntrustedDomains_Correct_V4 if {
     # Test Links and External Images Protections when there's multiple events and the most recent is correct
     PolicyId := "GWS.GMAIL.6.3v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/gmail/gmail07_test.rego
+++ b/Testing/RegoTests/gmail/gmail07_test.rego
@@ -1270,7 +1270,7 @@ test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Correct_V3 if {
+test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Correct_V4 if {
     # Test Spoofing and Authentication Protections when there's correct events in multiple OUs
     PolicyId := "GWS.GMAIL.7.4v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/gmail/gmail07_test.rego
+++ b/Testing/RegoTests/gmail/gmail07_test.rego
@@ -128,7 +128,7 @@ test_SpoofingAuthenticationProtectionSimilarDomainNameSpoofing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -178,7 +178,7 @@ test_SpoofingAuthenticationProtectionSimilarDomainNameSpoofing_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -378,7 +378,7 @@ test_SpoofingAuthenticationProtectionSimilarDomainNameSpoofing_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -508,7 +508,7 @@ test_SpoofingAuthenticationProtectionEmployeeNameSpoofing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -554,7 +554,7 @@ test_SpoofingAuthenticationProtectionEmployeeNameSpoofing_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -742,7 +742,7 @@ test_SpoofingAuthenticationProtectionEmployeeNameSpoofing_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -880,7 +880,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofing_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -930,7 +930,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofing_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1130,7 +1130,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofing_Incorrect_V5 if 
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1259,7 +1259,7 @@ test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1305,7 +1305,7 @@ test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1494,7 +1494,7 @@ test_SpoofingAuthenticationProtectionUnauthenticatedEmail_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -1632,7 +1632,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofingGroups_Correct_V3
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1682,7 +1682,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofingGroups_Correct_V4
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -1882,7 +1882,7 @@ test_SpoofingAuthenticationProtectionInboundEmailDomainSpoofingGroups_Incorrect_
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -2305,7 +2305,7 @@ test_SpoofingAuthenticationProtectionFutureRecommendedSettings_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -2355,7 +2355,7 @@ test_SpoofingAuthenticationProtectionFutureRecommendedSettings_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -2555,7 +2555,7 @@ test_SpoofingAuthenticationProtectionFutureRecommendedSettings_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail08_test.rego
+++ b/Testing/RegoTests/gmail/gmail08_test.rego
@@ -98,7 +98,7 @@ test_UserEmailUploads_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -262,7 +262,7 @@ test_UserEmailUploads_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail09_test.rego
+++ b/Testing/RegoTests/gmail/gmail09_test.rego
@@ -99,7 +99,7 @@ test_ImapAccess_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -137,7 +137,7 @@ test_ImapAccess_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -300,7 +300,7 @@ test_ImapAccess_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -408,7 +408,7 @@ test_PopAccess_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -446,7 +446,7 @@ test_PopAccess_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -610,7 +610,7 @@ test_PopAccess_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail09_test.rego
+++ b/Testing/RegoTests/gmail/gmail09_test.rego
@@ -419,7 +419,7 @@ test_PopAccess_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs."
 }
 
-test_PopAccess_Correct_V3 if {
+test_PopAccess_Correct_V4 if {
     # Test POP Access when there's correct events in multiple OUs
     PolicyId := "GWS.GMAIL.9.2v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/gmail/gmail10_test.rego
+++ b/Testing/RegoTests/gmail/gmail10_test.rego
@@ -98,7 +98,7 @@ test_GoogleWorkspaceSync_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -136,7 +136,7 @@ test_GoogleWorkspaceSync_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -300,7 +300,7 @@ test_GoogleWorkspaceSync_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail11_test.rego
+++ b/Testing/RegoTests/gmail/gmail11_test.rego
@@ -98,7 +98,7 @@ test_AutomaticForwarding_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -136,7 +136,7 @@ test_AutomaticForwarding_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -300,7 +300,7 @@ test_AutomaticForwarding_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail12_test.rego
+++ b/Testing/RegoTests/gmail/gmail12_test.rego
@@ -98,7 +98,7 @@ test_ImageUrlProxyWhitelist_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -262,7 +262,7 @@ test_ImageUrlProxyWhitelist_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail13_test.rego
+++ b/Testing/RegoTests/gmail/gmail13_test.rego
@@ -98,7 +98,7 @@ test_PerUserOutboundGateway_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -262,7 +262,7 @@ test_PerUserOutboundGateway_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail14_test.rego
+++ b/Testing/RegoTests/gmail/gmail14_test.rego
@@ -113,7 +113,7 @@ test_ExternalReplyWarning_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -157,7 +157,7 @@ test_ExternalReplyWarning_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -339,7 +339,7 @@ test_ExternalReplyWarning_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail16_test.rego
+++ b/Testing/RegoTests/gmail/gmail16_test.rego
@@ -113,7 +113,7 @@ test_EnhancedPreDeliveryMessageScanning_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -157,7 +157,7 @@ test_EnhancedPreDeliveryMessageScanning_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -338,7 +338,7 @@ test_EnhancedPreDeliveryMessageScanning_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/gmail/gmail17_test.rego
+++ b/Testing/RegoTests/gmail/gmail17_test.rego
@@ -98,7 +98,7 @@ test_SecuritySandbox_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -136,7 +136,7 @@ test_SecuritySandbox_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -300,7 +300,7 @@ test_SecuritySandbox_Incorrect_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/groups/groups01_test.rego
+++ b/Testing/RegoTests/groups/groups01_test.rego
@@ -26,7 +26,7 @@ test_GroupAccess_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -64,7 +64,7 @@ test_GroupAccess_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,11 +92,15 @@ test_GroupsAccess_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 #TODO
@@ -121,7 +125,7 @@ test_GroupAccess_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -159,7 +163,7 @@ test_GroupAccess_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups02_test.rego
+++ b/Testing/RegoTests/groups/groups02_test.rego
@@ -14,7 +14,10 @@ test_GroupAddExternal_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -26,7 +29,7 @@ test_GroupAddExternal_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -34,7 +37,8 @@ test_GroupAddExternal_Correct_V1 if {
 }
 
 test_GroupAddExternal_Correct_V2 if {
-    # Test group owners' ability to add external memebers when there's multiple events and the most most recent is correct
+    # Test group owners' ability to add external memebers when there's
+    # multiple events and the most most recent is correct
     PolicyId := "GWS.GROUPS.2.1v0.1"
     Output := tests with input as {
         "groups_logs": {"items": [
@@ -42,7 +46,10 @@ test_GroupAddExternal_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -52,7 +59,10 @@ test_GroupAddExternal_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -64,7 +74,7 @@ test_GroupAddExternal_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,11 +102,15 @@ test_GroupAddExternal_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_GroupAddExternal_Incorrect_V2 if {
@@ -108,7 +122,10 @@ test_GroupAddExternal_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -120,7 +137,7 @@ test_GroupAddExternal_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -136,7 +153,10 @@ test_GroupAddExternal_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -146,7 +166,10 @@ test_GroupAddExternal_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_external_members"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_external_members"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -158,7 +181,7 @@ test_GroupAddExternal_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups03_test.rego
+++ b/Testing/RegoTests/groups/groups03_test.rego
@@ -14,7 +14,10 @@ test_GroupIncomingMailPosting_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -26,7 +29,7 @@ test_GroupIncomingMailPosting_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -34,7 +37,8 @@ test_GroupIncomingMailPosting_Correct_V1 if {
 }
 
 test_GroupIncomingMailPosting_Correct_V2 if {
-    # Test group owners' ability to allow incoming mail for posting group messages when there's multiple events and the most most recent is correct
+    # Test group owners' ability to allow incoming mail for posting group messages when
+    # there's multiple events and the most most recent is correct
     PolicyId := "GWS.GROUPS.3.1v0.1"
     Output := tests with input as {
         "groups_logs": {"items": [
@@ -42,7 +46,10 @@ test_GroupIncomingMailPosting_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -52,7 +59,10 @@ test_GroupIncomingMailPosting_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -64,7 +74,7 @@ test_GroupIncomingMailPosting_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,15 +102,20 @@ test_GroupIncomingMailPosting_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_GroupIncomingMailPosting_Incorrect_V2 if {
-    # Test group owners' ability to allow incoming mail for posting group messages when there's only one event and it's wrong
+    # Test group owners' ability to allow incoming mail for posting group messages when
+    # there's only one event and it's wrong
     PolicyId := "GWS.GROUPS.3.1v0.1"
     Output := tests with input as {
         "groups_logs": {"items": [
@@ -108,7 +123,10 @@ test_GroupIncomingMailPosting_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -120,7 +138,7 @@ test_GroupIncomingMailPosting_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -128,7 +146,8 @@ test_GroupIncomingMailPosting_Incorrect_V2 if {
 }
 
 test_GroupIncomingMailPosting_Incorrect_V3 if {
-    # Test group owners' ability to allow incoming mail for posting group messages when there are multiple events and the most recent is wrong
+    # Test group owners' ability to allow incoming mail for posting group messages
+    # when there are multiple events and the most recent is wrong
     PolicyId := "GWS.GROUPS.3.1v0.1"
     Output := tests with input as {
         "groups_logs": {"items": [
@@ -136,7 +155,10 @@ test_GroupIncomingMailPosting_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -146,7 +168,10 @@ test_GroupIncomingMailPosting_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -158,7 +183,7 @@ test_GroupIncomingMailPosting_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups04_test.rego
+++ b/Testing/RegoTests/groups/groups04_test.rego
@@ -26,7 +26,7 @@ test_GroupCreation_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_GroupCreation_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -91,11 +91,15 @@ test_GroupCreation_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_GroupCreation_Incorrect_V2 if {
@@ -119,7 +123,7 @@ test_GroupCreation_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -157,7 +161,7 @@ test_GroupCreation_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups05_test.rego
+++ b/Testing/RegoTests/groups/groups05_test.rego
@@ -14,7 +14,10 @@ test_GroupConservationViewPermission_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MEMBERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -26,7 +29,7 @@ test_GroupConservationViewPermission_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -42,7 +45,10 @@ test_GroupConservationViewPermission_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MEMBERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -52,7 +58,10 @@ test_GroupConservationViewPermission_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "DOMAIN_USERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -64,7 +73,7 @@ test_GroupConservationViewPermission_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,11 +101,15 @@ test_GroupConservationViewPermission_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_GroupConservationViewPermission_Incorrect_V2 if {
@@ -108,7 +121,10 @@ test_GroupConservationViewPermission_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "DOMAIN_USERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -120,7 +136,7 @@ test_GroupConservationViewPermission_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -136,7 +152,10 @@ test_GroupConservationViewPermission_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MANAGERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -148,7 +167,7 @@ test_GroupConservationViewPermission_Incorrect_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -164,7 +183,10 @@ test_GroupConservationViewPermission_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "OWNERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -176,7 +198,7 @@ test_GroupConservationViewPermission_Incorrect_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -192,7 +214,10 @@ test_GroupConservationViewPermission_Incorrect_V5 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "DOMAIN_USERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -202,7 +227,10 @@ test_GroupConservationViewPermission_Incorrect_V5 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MEMBERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -214,7 +242,7 @@ test_GroupConservationViewPermission_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -230,7 +258,10 @@ test_GroupConservationViewPermission_Incorrect_V6 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MANAGERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -240,7 +271,10 @@ test_GroupConservationViewPermission_Incorrect_V6 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MEMBERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -252,7 +286,7 @@ test_GroupConservationViewPermission_Incorrect_V6 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -268,7 +302,10 @@ test_GroupConservationViewPermission_Incorrect_V7 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "OWNERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -278,7 +315,10 @@ test_GroupConservationViewPermission_Incorrect_V7 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "GroupsSharingSettingsProto default_view_topics_access_level"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "GroupsSharingSettingsProto default_view_topics_access_level"
+                        },
                         {"name": "NEW_VALUE", "value": "MEMBERS"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -290,7 +330,7 @@ test_GroupConservationViewPermission_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups06_test.rego
+++ b/Testing/RegoTests/groups/groups06_test.rego
@@ -195,7 +195,7 @@ test_GroupOwnersHideGroups_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/groups/groups06_test.rego
+++ b/Testing/RegoTests/groups/groups06_test.rego
@@ -26,7 +26,7 @@ test_GroupOwnersHideGroups_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -64,7 +64,7 @@ test_GroupOwnersHideGroups_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -92,11 +92,15 @@ test_GroupOwnersHideGroups_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_GroupOwnersHideGroups_Incorrect_V2 if {
@@ -120,7 +124,7 @@ test_GroupOwnersHideGroups_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -158,7 +162,7 @@ test_GroupOwnersHideGroups_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -195,7 +199,7 @@ test_GroupOwnersHideGroups_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups07_test.rego
+++ b/Testing/RegoTests/groups/groups07_test.rego
@@ -24,7 +24,7 @@ test_Group_Correct_V1 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -61,7 +61,7 @@ test_Group_Correct_V2 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -77,7 +77,7 @@ test_Group_Correct_V3 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -103,7 +103,7 @@ test_Group_Incorrect_V1 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
@@ -141,7 +141,7 @@ test_Group_Correct_V2 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -178,7 +178,7 @@ test_Group_Correct_V3 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -215,7 +215,7 @@ test_Group_Correct_V3 if {
         ]
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups07_test.rego
+++ b/Testing/RegoTests/groups/groups07_test.rego
@@ -104,7 +104,6 @@ test_Group_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/groups/groups07_test.rego
+++ b/Testing/RegoTests/groups/groups07_test.rego
@@ -110,7 +110,7 @@ test_Group_Incorrect_V1 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Group 1."
 }
 
-test_Group_Correct_V2 if {
+test_Group_Incorrect_V2 if {
     # Test multiple groups where 1 is incorrect
     PolicyId := "GWS.GROUPS.7.1v0.1"
     Output := tests with input as {
@@ -147,7 +147,7 @@ test_Group_Correct_V2 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Group 2."
 }
 
-test_Group_Correct_V3 if {
+test_Group_Incorrect_V3 if {
     # Test multiple groups where both are incorrect
     PolicyId := "GWS.GROUPS.7.1v0.1"
     Output := tests with input as {
@@ -184,7 +184,7 @@ test_Group_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement failed in Group 1, Group 2."
 }
 
-test_Group_Correct_V3 if {
+test_Group_Incorrect_V4 if {
     # Test multiple groups where both are incorrect in multiple ways
     PolicyId := "GWS.GROUPS.7.1v0.1"
     Output := tests with input as {

--- a/Testing/RegoTests/meet/meet01_test.rego
+++ b/Testing/RegoTests/meet/meet01_test.rego
@@ -26,7 +26,7 @@ test_Access_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -64,7 +64,7 @@ test_Access_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_Access_Correct_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -150,7 +150,7 @@ test_Access_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -178,11 +178,15 @@ test_Access_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_Access_Incorrect_V2 if {
@@ -206,7 +210,7 @@ test_Access_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -244,7 +248,7 @@ test_Access_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -282,7 +286,7 @@ test_Access_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -311,12 +315,15 @@ test_Access_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
-}
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])}
 
 test_Access_Incorrect_V6 if {
     # Test meeting access when there's only one event and it's wrong
@@ -339,7 +346,7 @@ test_Access_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -377,7 +384,7 @@ test_Access_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -415,7 +422,7 @@ test_Access_Incorrect_V8 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -444,10 +451,13 @@ test_Access_Incorrect_V9 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
-}
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])}
 #--

--- a/Testing/RegoTests/meet/meet01_test.rego
+++ b/Testing/RegoTests/meet/meet01_test.rego
@@ -98,7 +98,7 @@ test_Access_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -146,7 +146,7 @@ test_Access_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -282,7 +282,7 @@ test_Access_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -418,7 +418,7 @@ test_Access_Incorrect_V8 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/meet/meet02_test.rego
+++ b/Testing/RegoTests/meet/meet02_test.rego
@@ -26,7 +26,7 @@ test_JoinExternalPers_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -64,7 +64,7 @@ test_JoinExternalPers_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -102,7 +102,7 @@ test_JoinExternalPers_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -150,7 +150,7 @@ test_History_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -178,7 +178,7 @@ test_JoinExternalPers_Correct_V5 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -216,7 +216,7 @@ test_JoinExternalPers_Correct_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -254,7 +254,7 @@ test_JoinExternalPers_Correct_V7 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -302,7 +302,7 @@ test_History_Correct_V8 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -330,11 +330,15 @@ test_JoinExternalPers_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_JoinExternalPers_Incorrect_V2 if {
@@ -358,7 +362,7 @@ test_JoinExternalPers_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -397,7 +401,7 @@ test_JoinExternalPers_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -435,7 +439,7 @@ test_JoinExternalPers_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -464,11 +468,15 @@ test_JoinExternalPers_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_JoinExternalPers_Incorrect_V6 if {
@@ -492,7 +500,7 @@ test_JoinExternalPers_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -531,77 +539,9 @@ test_JoinExternalPers_Incorrect_V7 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
     RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
 }
-
-# test_JoinExternalPers_Incorrect_V4 if {
-#     # Test allow user to change history setting when there are multiple OU and a secondary OU is wrong
-#     PolicyId := "GWS.MEET.2.1v0.1"
-#     Output := tests with input as {
-#         "meet_logs": {"items": [
-#             {
-#                 "id": {"time": "2021-12-20T00:02:28.672Z"},
-#                 "events": [{
-#                     "parameters": [
-#                         {"name": "SETTING_NAME", "value": "SafetyAccessLockProto meetings_allowed_to_join"},
-#                         {"name": "NEW_VALUE", "value": "WORKSPACE_DOMAINS"},
-#                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
-#                     ]
-#                 }]
-#             },
-#             {
-#                 "id": {"time": "2022-12-20T00:02:28.672Z"},
-#                 "events": [{
-#                     "parameters": [
-#                         {"name": "SETTING_NAME", "value": "SafetyAccessLockProto meetings_allowed_to_join"},
-#                         {"name": "NEW_VALUE", "value": "ALL"},
-#                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
-#                     ]
-#                 }]
-#             }
-#         ]},
-#         "tenant_info": {
-#             "topLevelOU": ""
-#         },
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     not RuleOutput[0].NoSuchEvent
-#     RuleOutput[0].ReportDetails == "Requirement failed in Test Secondary OU."
-# }
-#--
-
-# test_JoinExternalPers_Incorrect_V5 if {
-#     # Test allow user to change history setting when the primary OU is missing but a different one is present
-#     PolicyId := "GWS.MEET.2.1v0.1"
-#     Output := tests with input as {
-#         "meet_logs": {"items": [
-#             {
-#                 "id": {"time": "2022-12-20T00:02:28.672Z"},
-#                 "events": [{
-#                     "parameters": [
-#                         {"name": "SETTING_NAME", "value": "SafetyAccessLockProto meetings_allowed_to_join"},
-#                         {"name": "NEW_VALUE", "value": "ALL"},
-#                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
-#                     ]
-#                 }]
-#             }
-#         ]},
-#         "tenant_info": {
-#             "topLevelOU": "Test Top-Level OU"
-#         },
-#     }
-
-#     RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
-#     count(RuleOutput) == 1
-#     not RuleOutput[0].RequirementMet
-#     RuleOutput[0].NoSuchEvent
-#     RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
-# }
-#--

--- a/Testing/RegoTests/meet/meet02_test.rego
+++ b/Testing/RegoTests/meet/meet02_test.rego
@@ -98,7 +98,7 @@ test_JoinExternalPers_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -146,7 +146,7 @@ test_History_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -250,7 +250,7 @@ test_JoinExternalPers_Correct_V7 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -298,7 +298,7 @@ test_History_Correct_V8 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -435,7 +435,7 @@ test_JoinExternalPers_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
@@ -535,7 +535,7 @@ test_JoinExternalPers_Incorrect_V7 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/meet/meet03_test.rego
+++ b/Testing/RegoTests/meet/meet03_test.rego
@@ -25,7 +25,7 @@ test_HostMan_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -63,7 +63,7 @@ test_HostMan_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -101,7 +101,7 @@ test_HostMan_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -149,7 +149,7 @@ test_Access_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -177,11 +177,15 @@ test_HostMan_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_HostMan_Incorrect_V2 if {
@@ -205,7 +209,7 @@ test_HostMan_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -243,7 +247,7 @@ test_HostMan_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -281,7 +285,7 @@ test_HostMan_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -310,10 +314,14 @@ test_HostMan_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/meet/meet03_test.rego
+++ b/Testing/RegoTests/meet/meet03_test.rego
@@ -97,7 +97,7 @@ test_HostMan_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -145,7 +145,7 @@ test_Access_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -281,7 +281,7 @@ test_HostMan_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/meet/meet04_test.rego
+++ b/Testing/RegoTests/meet/meet04_test.rego
@@ -13,7 +13,11 @@ test_HostMan_Correct_V1 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -25,7 +29,7 @@ test_HostMan_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -41,7 +45,11 @@ test_HostMan_Correct_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -51,7 +59,11 @@ test_HostMan_Correct_V2 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -63,7 +75,7 @@ test_HostMan_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -79,7 +91,11 @@ test_HostMan_Correct_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -89,7 +105,11 @@ test_HostMan_Correct_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -101,7 +121,7 @@ test_HostMan_Correct_V3 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -117,7 +137,11 @@ test_Access_Correct_V4 if {
                 "id": {"time": "2020-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -128,7 +152,11 @@ test_Access_Correct_V4 if {
                 "events": [{
                     "name": "DELETE_APPLICATION_SETTING",
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
                 }]
@@ -137,7 +165,11 @@ test_Access_Correct_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
                     ]
@@ -149,7 +181,7 @@ test_Access_Correct_V4 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -177,11 +209,15 @@ test_HostMan_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 
 test_HostMan_Incorrect_V2 if {
@@ -193,7 +229,11 @@ test_HostMan_Incorrect_V2 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -205,7 +245,7 @@ test_HostMan_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -221,7 +261,11 @@ test_HostMan_Incorrect_V3 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -231,7 +275,11 @@ test_HostMan_Incorrect_V3 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -243,7 +291,7 @@ test_HostMan_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -259,7 +307,11 @@ test_HostMan_Incorrect_V4 if {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
@@ -269,7 +321,11 @@ test_HostMan_Incorrect_V4 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "false"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -281,7 +337,7 @@ test_HostMan_Incorrect_V4 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -298,7 +354,11 @@ test_HostMan_Incorrect_V5 if {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
                     "parameters": [
-                        {"name": "SETTING_NAME", "value": "Warn for external participants External or unidentified participants in a meeting are given a label"},
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
                         {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Secondary OU"},
                     ]
@@ -310,10 +370,14 @@ test_HostMan_Incorrect_V5 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
 #--

--- a/Testing/RegoTests/meet/meet04_test.rego
+++ b/Testing/RegoTests/meet/meet04_test.rego
@@ -117,7 +117,7 @@ test_HostMan_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -177,7 +177,7 @@ test_Access_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
@@ -333,7 +333,7 @@ test_HostMan_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 

--- a/Testing/RegoTests/sites/sites01_test.rego
+++ b/Testing/RegoTests/sites/sites01_test.rego
@@ -28,7 +28,6 @@ test_Sites_Disabled_Correct_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -252,7 +251,6 @@ test_Sites_Disabled_Incorrect_V1 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -420,7 +418,6 @@ test_Sites_Disabled_Incorrect_V6 if {
     }
 
     RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
-    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent

--- a/Testing/RegoTests/sites/sites01_test.rego
+++ b/Testing/RegoTests/sites/sites01_test.rego
@@ -13,6 +13,7 @@ test_Sites_Disabled_Correct_V1 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -26,7 +27,8 @@ test_Sites_Disabled_Correct_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    print(RuleOutput)
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -41,6 +43,7 @@ test_Sites_Disabled_Correct_V2 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -51,6 +54,7 @@ test_Sites_Disabled_Correct_V2 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -64,7 +68,7 @@ test_Sites_Disabled_Correct_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -79,6 +83,7 @@ test_Sites_Disabled_Correct_V3 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -89,6 +94,7 @@ test_Sites_Disabled_Correct_V3 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -98,11 +104,11 @@ test_Sites_Disabled_Correct_V3 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -117,6 +123,7 @@ test_Sites_Disabled_Correct_V4 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -127,6 +134,7 @@ test_Sites_Disabled_Correct_V4 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -137,6 +145,7 @@ test_Sites_Disabled_Correct_V4 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -146,11 +155,11 @@ test_Sites_Disabled_Correct_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -166,6 +175,7 @@ test_Sites_Disabled_Correct_V5 if {
             {
                 "id": {"time": "2022-12-10T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -176,6 +186,7 @@ test_Sites_Disabled_Correct_V5 if {
             {
                 "id": {"time": "2022-12-20T00:02:29.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -186,6 +197,7 @@ test_Sites_Disabled_Correct_V5 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "INHERIT_FROM_PARENT"},
@@ -195,11 +207,11 @@ test_Sites_Disabled_Correct_V5 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -207,16 +219,28 @@ test_Sites_Disabled_Correct_V5 if {
 }
 
 test_Sites_Disabled_Incorrect_V1 if {
-    # Test sites is disabled when there are no relevant events
+    # Test sites is disabled when there is an event for a different service
     PolicyId := "GWS.SITES.1.1v0.1"
     Output := tests with input as {
         "sites_logs": {"items": [
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Something else"}, 
-                        {"name": "NEW_VALUE", "value": "SHARING_NOT_ALLOWED"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2021-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Sites"}, 
+                        {"name": "NEW_VALUE", "value": "true"},
                         {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
                     ]
                 }]
@@ -227,11 +251,12 @@ test_Sites_Disabled_Incorrect_V1 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
-    RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
 }
 
 test_Sites_Disabled_Incorrect_V2 if {
@@ -242,6 +267,7 @@ test_Sites_Disabled_Incorrect_V2 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -255,7 +281,7 @@ test_Sites_Disabled_Incorrect_V2 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -270,6 +296,7 @@ test_Sites_Disabled_Incorrect_V3 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -280,6 +307,7 @@ test_Sites_Disabled_Incorrect_V3 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -293,7 +321,7 @@ test_Sites_Disabled_Incorrect_V3 if {
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -308,6 +336,7 @@ test_Sites_Disabled_Incorrect_V4 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "false"},
@@ -318,6 +347,7 @@ test_Sites_Disabled_Incorrect_V4 if {
             {
                 "id": {"time": "2021-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -327,11 +357,11 @@ test_Sites_Disabled_Incorrect_V4 if {
             }
         ]},
         "tenant_info": {
-            "topLevelOU": ""
+            "topLevelOU": "Test Top-Level OU"
         },
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -346,6 +376,7 @@ test_Sites_Disabled_Incorrect_V5 if {
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Sites"},
                         {"name": "NEW_VALUE", "value": "true"},
@@ -359,7 +390,7 @@ test_Sites_Disabled_Incorrect_V5 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
@@ -367,13 +398,14 @@ test_Sites_Disabled_Incorrect_V5 if {
 }
 
 test_Sites_Disabled_Incorrect_V6 if {
-    # Test sites is disabled when there are no relevant events for Sites, but there is an event for a different service
+    # Test sites is disabled when there are no relevant events
     PolicyId := "GWS.SITES.1.1v0.1"
     Output := tests with input as {
         "sites_logs": {"items": [
             {
                 "id": {"time": "2022-12-20T00:02:28.672Z"},
                 "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
                     "parameters": [
                         {"name": "SERVICE_NAME", "value": "Something else"}, 
                         {"name": "NEW_VALUE", "value": "false"},
@@ -387,10 +419,15 @@ test_Sites_Disabled_Incorrect_V6 if {
         }
     }
 
-    RuleOutput := [Result | Result = Output[_]; Result.PolicyId == PolicyId]
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    print(RuleOutput)
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "No relevant event in the current logs for the top-level OU, Test Top-Level OU. While we are unable to determine the state from the logs, the default setting is non-compliant; manual check recommended."
+    RuleOutput[0].ReportDetails == concat("", [
+        "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
+        "While we are unable to determine the state from the logs, the default setting ",
+        "is non-compliant; manual check recommended."
+    ])
 }
-# #--
+#--

--- a/Testing/run_unit_tests.py
+++ b/Testing/run_unit_tests.py
@@ -7,9 +7,6 @@ import subprocess
 import argparse
 from sys import platform
 
-# to_do move items from the commented out list below as the tests
-#  are implemented so they will be run by default
-
 gws_baselines = [
     "gmail",
     "calendar",

--- a/Testing/run_unit_tests.py
+++ b/Testing/run_unit_tests.py
@@ -16,8 +16,6 @@ gws_baselines = [
     "meet",
     "sites",
     "commoncontrols",
-    "sites",
-    "commoncontrols",
     "rules",
     'classroom'
 ]

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -124,9 +124,9 @@ GetLastEvent(Events) := Event if {
 }
 
 
-################
-# Baseline 1   #
-################
+##################
+# GWS.CALENDAR.1 #
+##################
 
 #
 # Baseline GWS.CALENDAR.1.1v0.1
@@ -174,7 +174,7 @@ if {
 
 #
 # Baseline GWS.CALENDAR.1.2v0.1
-#
+#--
 tests contains {
     "PolicyId": "GWS.CALENDAR.1.2v0.1",
     "Criticality": "May/Not-Implemented",
@@ -185,9 +185,9 @@ tests contains {
 }
 #--
 
-################
-# Baseline 2   #
-################
+##################
+# GWS.CALENDAR.2 #
+##################
 
 #
 # Baseline GWS.CALENDAR.2.1v0.1
@@ -233,9 +233,9 @@ if {
 #--
 
 
-################
-# Baseline 3 #
-################
+##################
+# GWS.CALENDAR.3 #
+##################
 
 ExtSharingSecondaryCalSettingDetailsStr(LastEvent) := Description if {
     LastEvent.NewValue == "SHOW_ONLY_FREE_BUSY_INFORMATION"
@@ -307,7 +307,7 @@ if {
 
 #
 # Baseline GWS.CALENDAR.3.2v0.1
-#
+#--
 tests contains {
     "PolicyId": "GWS.CALENDAR.3.2v0.1",
     "Criticality": "May/Not-Implemented",
@@ -320,9 +320,9 @@ tests contains {
 
 
 
-################
-# Baseline 4   #
-################
+##################
+# GWS.CALENDAR.4 #
+##################
 
 CalInteropManSettingDetailsStr(LastEvent) := Description if {
     LastEvent.NewValue == "true"
@@ -374,7 +374,6 @@ if {
 #--
 
 
-#--
 #
 # Baseline GWS.CALENDAR.4.2v0.1
 #--
@@ -388,14 +387,13 @@ tests contains {
 }
 #--
 
-################
-# Baseline 5   #
-################
+##################
+# GWS.CALENDAR.5 #
+##################
 
 # Extreme outlier. Logs for this event have no Domain
 # As such we need to create custom FilterEventsOU function and SettingChangeEvent
 # Functions
-
 SettingChangeEventsNoDomain contains {
     "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
@@ -472,7 +470,6 @@ NonCompliantOUs5_1 contains OU if {
     LastEvent.NewValue != "false"
 }
 
-#--
 #
 # Baseline GWS.CALENDAR.5.1v0.1
 #--

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -10,7 +10,7 @@ OUsWithEvents contains Event.OrgUnit if {
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName
     Events := SettingChangeEvents
-    FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
+    FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -21,11 +21,11 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [
+    FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -35,7 +35,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -44,7 +44,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 TopLevelOU := Name if {
@@ -115,7 +115,7 @@ GetLastEvent(Events) := Event if {
     # Because CalendarSharingEvents returns a set instead
     # of an array, we can't just index it and get the last
     # value
-    MaxTs := max([Event.Timestamp | some Event in Events])
+    MaxTs := max({Event.Timestamp | some Event in Events})
     some Event in Events
     Event.Timestamp == MaxTs
 }

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -1,12 +1,7 @@
 package calendar
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.FilterEvents
-import data.utils.GetLastEvent
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.FilterEventsNoOU
-import data.utils.NoSuchEventDetails
 
 ##################
 # GWS.CALENDAR.1 #
@@ -16,13 +11,13 @@ import data.utils.NoSuchEventDetails
 # Baseline GWS.CALENDAR.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "SHOW_ONLY_FREE_BUSY_INFORMATION"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -30,27 +25,27 @@ NonCompliantOUs1_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CALENDAR.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs.",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CALENDAR.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -77,40 +72,40 @@ tests contains {
 # Baseline GWS.CALENDAR.2.1v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
 }
 
 tests contains {
     "PolicyId": "GWS.CALENDAR.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CALENDAR.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -162,14 +157,14 @@ ExtSharingSecondaryCalSettingDetailsStr(LastEvent) := Description if {
 tests contains {
     "PolicyId": "GWS.CALENDAR.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
+    Events := utils.FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
     count(Events) == 0
 }
 
@@ -182,9 +177,9 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
+    Events := utils.FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "SHOW_ONLY_FREE_BUSY_INFORMATION"
 }
 #--
@@ -230,14 +225,14 @@ CalInteropManSettingDetailsStr(LastEvent) := Description if {
 tests contains {
     "PolicyId": "GWS.CALENDAR.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsNoOU("ENABLE_EWS_INTEROP")
+    Events := utils.FilterEventsNoOU("ENABLE_EWS_INTEROP")
     count(Events) == 0
 }
 
@@ -250,9 +245,9 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsNoOU("ENABLE_EWS_INTEROP")
+    Events := utils.FilterEventsNoOU("ENABLE_EWS_INTEROP")
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "false"
 }
 #--
@@ -277,13 +272,13 @@ tests contains {
 
 
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
 }
 
@@ -293,27 +288,27 @@ NonCompliantOUs5_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CALENDAR.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs.",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", TopLevelOU)
+    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CALENDAR.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", TopLevelOU)
+    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -1,6 +1,7 @@
 package calendar
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -79,15 +80,6 @@ if {
     NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
     DomainName := GetEventDomain(Event)
-}
-
-GetLastEvent(Events) := Event if {
-    # Because CalendarSharingEvents returns a set instead
-    # of an array, we can't just index it and get the last
-    # value
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -13,14 +13,14 @@ FilterEvents(SettingName) := FilteredEvents if {
     FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
     FilteredEvents := [
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -1,5 +1,6 @@
 package calendar
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -42,34 +43,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 # Helper function so that the regular SettingChangeEvents

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -1,11 +1,8 @@
 package calendar
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
-}
 
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName

--- a/rego/Calendar.rego
+++ b/rego/Calendar.rego
@@ -3,6 +3,8 @@ package calendar
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("calendar_logs")
+
 ##################
 # GWS.CALENDAR.1 #
 ##################
@@ -12,7 +14,7 @@ import future.keywords
 #--
 NonCompliantOUs1_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -32,7 +34,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -45,7 +47,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -73,7 +75,7 @@ tests contains {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EXTERNAL_GUEST_PROMPT", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -92,7 +94,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -105,7 +107,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EXTERNAL_GUEST_PROMPT", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -164,7 +166,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
+    Events := utils.FilterEventsNoOU(LogEvents, "SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
     count(Events) == 0
 }
 
@@ -177,7 +179,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEventsNoOU("SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
+    Events := utils.FilterEventsNoOU(LogEvents, "SHARING_OUTSIDE_DOMAIN_FOR_SECONDARY_CALENDAR")
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "SHOW_ONLY_FREE_BUSY_INFORMATION"
@@ -232,7 +234,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEventsNoOU("ENABLE_EWS_INTEROP")
+    Events := utils.FilterEventsNoOU(LogEvents, "ENABLE_EWS_INTEROP")
     count(Events) == 0
 }
 
@@ -245,7 +247,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEventsNoOU("ENABLE_EWS_INTEROP")
+    Events := utils.FilterEventsNoOU(LogEvents, "ENABLE_EWS_INTEROP")
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "false"
@@ -273,7 +275,7 @@ tests contains {
 
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", OU)
+    Events := utils.FilterEvents(LogEvents, "CalendarAppointmentSlotAdminSettingsProto payments_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -295,7 +297,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", utils.TopLevelOU)
+    SettingName := "CalendarAppointmentSlotAdminSettingsProto payments_enabled"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -308,7 +311,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("CalendarAppointmentSlotAdminSettingsProto payments_enabled", utils.TopLevelOU)
+    SettingName := "CalendarAppointmentSlotAdminSettingsProto payments_enabled"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -85,16 +85,18 @@ GetTopLevelOU() := name if {
     name := ""
 }
 
-OUsWithEvents[Event.OrgUnit] {
+OUsWithEvents contains Event.OrgUnit if {
     some Event in SettingChangeEvents
 }
 
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
+    "OrgUnit": OrgUnit
+}
+if {
     some Item in input.chat_logs.items # For each item...
     some Event in Item.events # For each event in the item...
 
@@ -114,12 +116,14 @@ SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
 # minimal special logic, this rule adds the DELETE_APPLICATION_SETTING
 # to the SettingChangeEvents set, with "DELETE_APPLICATION_SETTING" as
 # the NewValue.
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
+    "OrgUnit": OrgUnit
+}
+if {
     some Item in input.chat_logs.items # For each item...
     some Event in Item.events # For each event in the item...
     Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
@@ -148,7 +152,7 @@ GetLastEvent(Events) := Event if {
 # Baseline GWS.CHAT.1v1
 #--
 
-NonCompliantOUs1_1[OU] {
+NonCompliantOUs1_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -159,24 +163,30 @@ NonCompliantOUs1_1[OU] {
     LastEvent.NewValue == "true"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
     count(Events) > 0
@@ -188,7 +198,7 @@ tests[{ "PolicyId": "GWS.CHAT.1.1v0.1",
 # Baseline GWS.CHAT.1.2v0.1
 #--
 
-NonCompliantOUs1_2[OU] {
+NonCompliantOUs1_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -199,24 +209,30 @@ NonCompliantOUs1_2[OU] {
     LastEvent.NewValue == "true"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.1.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.1.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)    
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.1.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.1.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
     count(Events) > 0
@@ -233,7 +249,7 @@ tests[{ "PolicyId": "GWS.CHAT.1.2v0.1",
 # Baseline GWS.CHAT.2.2v0.1
 #--
 
-NonCompliantOUs2_1[OU] {
+NonCompliantOUs2_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -245,24 +261,30 @@ NonCompliantOUs2_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.2.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)    
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.2.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)      
     count(Events) > 0
@@ -278,7 +300,7 @@ tests[{ "PolicyId": "GWS.CHAT.2.1v0.1",
 # Baseline GWS.CHAT.3.1v0.1
 #--
 
-NonCompliantOUs3_1[OU] {
+NonCompliantOUs3_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -289,24 +311,30 @@ NonCompliantOUs3_1[OU] {
     not contains("DEFAULT_ON_THE_RECORD ALWAYS_ON_THE_RECORD", LastEvent.NewValue)
 }
 
-tests[{ "PolicyId": "GWS.CHAT.3.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.3.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) > 0
@@ -321,7 +349,7 @@ tests[{ "PolicyId": "GWS.CHAT.3.1v0.1",
 #
 # Baseline GWS.CHAT.4.1v0.1
 #--
-NonCompliantOUs4_1[OU] {
+NonCompliantOUs4_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -332,24 +360,30 @@ NonCompliantOUs4_1[OU] {
     LastEvent.NewValue == "true"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.4.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.4.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) > 0
@@ -360,7 +394,7 @@ tests[{ "PolicyId": "GWS.CHAT.4.1v0.1",
 #
 # Baseline GWS.CHAT.4.2v0.1
 #--
-NonCompliantOUs4_2[OU] {
+NonCompliantOUs4_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("RestrictChatProto externalChatRestriction", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -371,24 +405,30 @@ NonCompliantOUs4_2[OU] {
     LastEvent.NewValue == "NO_RESTRICTION"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.4.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.4.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.4.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_2),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_2},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.4.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_2),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_2},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) > 0
@@ -404,7 +444,7 @@ tests[{ "PolicyId": "GWS.CHAT.4.2v0.1",
 # GWS.CHAT.5.1v0.1
 #--
 
-NonCompliantOUs5_1[OU] {
+NonCompliantOUs5_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -415,24 +455,31 @@ NonCompliantOUs5_1[OU] {
     LastEvent.NewValue == "true"
 }
 
-tests[{ "PolicyId": "GWS.CHAT.5.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CHAT.5.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CHAT.5.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains 
+{
+    "PolicyId": "GWS.CHAT.5.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) > 0
@@ -440,12 +487,12 @@ tests[{ "PolicyId": "GWS.CHAT.5.1v0.1",
 }
 #--
 
-tests[{ "PolicyId": "GWS.CHAT.6.1v0.1",
-        "Criticality": "Should/Not-Implemented",
-        "ReportDetails": "Currently not able to be tested automatically; please manually check.",
-        "ActualValue": "",
-        "RequirementMet": false,
-        "NoSuchEvent": true}]{
-    true
+tests contains {
+    "PolicyId": "GWS.CHAT.6.1v0.1",
+    "Criticality": "Should/Not-Implemented",
+    "ReportDetails": "Currently not able to be tested automatically; please manually check.",
+    "ActualValue": "",
+    "RequirementMet": false,
+    "NoSuchEvent": true
 }
 #--

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -1,5 +1,6 @@
 package chat
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -56,34 +57,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -5,7 +5,7 @@ import data.utils.NoSuchEventDetails
 
 FilterEvents(SettingName) := FilteredEvents if {
     Events := SettingChangeEvents
-    FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
+    FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
 }
 
 FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
@@ -16,11 +16,11 @@ FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both ServiceName and OrgUnit
     Events := FilterEvents(ServiceName)
-    FilteredEvents := [
+    FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
@@ -31,11 +31,11 @@ FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both ServiceName and OrgUnit
     Events := FilterEvents(ServiceName)
-    FilteredEvents := [
+    FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -45,7 +45,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -54,7 +54,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 TopLevelOU := Name if {
@@ -101,9 +101,9 @@ if {
     some Event in Item.events # For each event in the item...
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | some Parameter in Event.parameters] 
-    "NEW_VALUE" in [Parameter.name | some Parameter in Event.parameters]
-    "ORG_UNIT_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
@@ -129,8 +129,8 @@ if {
     Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | some Parameter in Event.parameters] 
-    "ORG_UNIT_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
@@ -139,7 +139,7 @@ if {
 }
 
 GetLastEvent(Events) := Event if {
-    MaxTs := max([Event.Timestamp | some Event in Events])
+    MaxTs := max({Event.Timestamp | some Event in Events})
     some Event in Events
     Event.Timestamp == MaxTs
 }

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -3,6 +3,8 @@ package chat
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("chat_logs")
+
 ##############
 # GWS.CHAT.1 #
 ##############
@@ -12,7 +14,7 @@ import future.keywords
 #--
 NonCompliantOUs1_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
+    Events := utils.FilterEvents(LogEvents, "ChatArchivingProto chatsDefaultToOffTheRecord", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -31,7 +33,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -44,7 +46,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -55,7 +57,7 @@ if {
 #--
 NonCompliantOUs1_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
+    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -74,7 +76,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", utils.TopLevelOU)
+    SettingName := "ChatArchivingProto allow_chat_archiving_setting_modification"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -87,7 +90,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", utils.TopLevelOU)
+    SettingName := "ChatArchivingProto allow_chat_archiving_setting_modification"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -103,7 +107,7 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
+    Events := utils.FilterEvents(LogEvents,  "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -123,7 +127,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", utils.TopLevelOU)
+    SettingName := "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -136,7 +141,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", utils.TopLevelOU)
+    SettingName := "DynamiteFileSharingSettingsProto external_file_sharing_setting"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -151,7 +157,7 @@ if {
 #--
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", OU)
+    Events := utils.FilterEvents(LogEvents,  "RoomOtrSettingsProto otr_state", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -170,7 +176,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -183,7 +189,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -198,7 +204,7 @@ if {
 #--
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", OU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto restrictChatToOrganization", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -217,7 +223,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -230,7 +236,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -241,7 +247,7 @@ if {
 #--
 NonCompliantOUs4_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", OU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto externalChatRestriction", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -260,7 +266,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -273,7 +279,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_2) == 0
 }
@@ -288,7 +294,7 @@ if {
 #--
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", OU)
+    Events := utils.FilterEvents(LogEvents,  "Chat app Settings - Chat apps enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -307,7 +313,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -320,7 +326,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -1,5 +1,6 @@
 package chat
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -83,10 +84,6 @@ TopLevelOU := Name if {
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
     Name := ""
-}
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
 }
 
 SettingChangeEvents contains {

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -1,11 +1,7 @@
 package chat
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.FilterEvents
-import data.utils.GetLastEvent
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.NoSuchEventDetails
 
 ##############
 # GWS.CHAT.1 #
@@ -15,40 +11,40 @@ import data.utils.NoSuchEventDetails
 # Baseline GWS.CHAT.1v1
 #--
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
+    Events := utils.FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
+    Events := utils.FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -58,40 +54,40 @@ if {
 # Baseline GWS.CHAT.1.2v0.1
 #--
 NonCompliantOUs1_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
+    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
+    Events := utils.FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -106,13 +102,13 @@ if {
 # Baseline GWS.CHAT.2.2v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "NO_FILES"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -120,27 +116,27 @@ NonCompliantOUs2_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CHAT.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
+    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
+    Events := utils.FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -154,40 +150,40 @@ if {
 # Baseline GWS.CHAT.3.1v0.1
 #--
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "RoomOtrSettingsProto otr_state", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     not contains("DEFAULT_ON_THE_RECORD ALWAYS_ON_THE_RECORD", LastEvent.NewValue)
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "RoomOtrSettingsProto otr_state", TopLevelOU)
+    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "RoomOtrSettingsProto otr_state", TopLevelOU)
+    Events := utils.FilterEvents( "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -201,40 +197,40 @@ if {
 # Baseline GWS.CHAT.4.1v0.1
 #--
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", TopLevelOU)
+    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", TopLevelOU)
+    Events := utils.FilterEvents( "RestrictChatProto restrictChatToOrganization", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -244,40 +240,40 @@ if {
 # Baseline GWS.CHAT.4.2v0.1
 #--
 NonCompliantOUs4_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "RestrictChatProto externalChatRestriction", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "NO_RESTRICTION"
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.4.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "RestrictChatProto externalChatRestriction", TopLevelOU)
+    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.4.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "RestrictChatProto externalChatRestriction", TopLevelOU)
+    Events := utils.FilterEvents( "RestrictChatProto externalChatRestriction", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_2) == 0
 }
@@ -291,40 +287,40 @@ if {
 # GWS.CHAT.5.1v0.1
 #--
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents( "Chat app Settings - Chat apps enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents( "Chat app Settings - Chat apps enabled", TopLevelOU)
+    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CHAT.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents( "Chat app Settings - Chat apps enabled", TopLevelOU)
+    Events := utils.FilterEvents( "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -144,14 +144,13 @@ GetLastEvent(Events) := Event if {
     Event.Timestamp == MaxTs
 }
 
-################
-# GWS.CHAT.1   #
-################
+##############
+# GWS.CHAT.1 #
+##############
 
 #
 # Baseline GWS.CHAT.1v1
 #--
-
 NonCompliantOUs1_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
@@ -195,7 +194,6 @@ if {
 #
 # Baseline GWS.CHAT.1.2v0.1
 #--
-
 NonCompliantOUs1_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", OU)
@@ -237,14 +235,13 @@ if {
 #--
 
 
-################
-# GWS.CHAT.2   #
-################
+##############
+# GWS.CHAT.2 #
+##############
 
 #
 # Baseline GWS.CHAT.2.2v0.1
 #--
-
 NonCompliantOUs2_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
@@ -286,14 +283,13 @@ if {
 }
 #--
 
-################
-# GWS.CHAT.3   #
-################
+##############
+# GWS.CHAT.3 #
+##############
 
 #
 # Baseline GWS.CHAT.3.1v0.1
 #--
-
 NonCompliantOUs3_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", OU)
@@ -334,9 +330,9 @@ if {
 }
 #--
 
-################
-# GWS.CHAT.4   #
-################
+##############
+# GWS.CHAT.4 #
+##############
 
 #
 # Baseline GWS.CHAT.4.1v0.1
@@ -424,14 +420,13 @@ if {
 }
 #--
 
-################
-# GWS.CHAT.5   #
-################
+##############
+# GWS.CHAT.5 #
+##############
 
 #
 # GWS.CHAT.5.1v0.1
 #--
-
 NonCompliantOUs5_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", OU)

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -57,14 +57,14 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Simplest case: if input.tenant_info.topLevelOU is
     # non-empty, it contains the name of the top-level OU.
     input.tenant_info.topLevelOU != ""
-    name := input.tenant_info.topLevelOU
+    Name := input.tenant_info.topLevelOU
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # input.tenant_info.topLevelOU will be empty when
     # no custom OUs have been created, as in this case
     # the top-level OU cannot be determined via the API.
@@ -73,16 +73,16 @@ GetTopLevelOU() := name if {
     # the events and know that it is the top-level OU
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) > 0
-    name := GetLastEvent(SettingChangeEvents).OrgUnit
+    Name := GetLastEvent(SettingChangeEvents).OrgUnit
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Extreme edge case: no custom OUs have been made
     # and the logs are empty. In this case, we really
     # have no way of determining the top-level OU name.
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
-    name := ""
+    Name := ""
 }
 
 OUsWithEvents contains Event.OrgUnit if {
@@ -173,7 +173,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
     count(Events) == 0
 }
@@ -187,7 +186,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
@@ -219,7 +217,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)    
     count(Events) == 0
 }
@@ -233,7 +230,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
@@ -271,7 +267,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)    
     count(Events) == 0
 }
@@ -285,7 +280,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)      
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -321,7 +315,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) == 0
 }
@@ -335,7 +328,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
@@ -370,7 +362,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) == 0
 }
@@ -384,7 +375,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
@@ -415,7 +405,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) == 0
 }
@@ -429,7 +418,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_2) == 0
@@ -465,7 +453,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) == 0
 }
@@ -480,7 +467,6 @@ tests contains
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -1,114 +1,11 @@
 package chat
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.FilterEvents
 import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
-
-FilterEvents(SettingName) := FilteredEvents if {
-    Events := SettingChangeEvents
-    FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
-}
-
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
-    # If there exists at least the root OU and 1 more OU
-    # filter out organizational units that don't exist
-    input.organizational_unit_names
-    count(input.organizational_unit_names) >=2
-
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := {
-        Event | some Event in Events;
-        Event.OrgUnit == OrgUnit;
-        Event.OrgUnit in input.organizational_unit_names
-    }
-}
-
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
-    # If there exists at least the root OU and 1 more OU
-    # filter out organizational units that don't exist
-    input.organizational_unit_names
-    count(input.organizational_unit_names) >=2
-
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := {
-        Event | some Event in Events;
-        Event.OrgUnit == OrgUnit;
-        Event.OrgUnit in input.organizational_unit_names
-    }
-}
-
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
-    # If only the root OU exists run like normal
-    input.organizational_unit_names
-    count(input.organizational_unit_names) < 2
-
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
-    # If OUs variable does not exist run like normal
-    not input.organizational_unit_names
-
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-SettingChangeEvents contains {
-    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
-    "TimestampStr": Item.id.time,
-    "NewValue": NewValue,
-    "Setting": Setting,
-    "OrgUnit": OrgUnit
-}
-if {
-    some Item in input.chat_logs.items # For each item...
-    some Event in Item.events # For each event in the item...
-
-    # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
-    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
-    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
-
-    # Extract the values
-    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
-    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
-    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-# Secondary case that looks for the DELETE_APPLICATION_SETTING events.
-# These events don't have a NEW_VALUE. To make these events work with
-# minimal special logic, this rule adds the DELETE_APPLICATION_SETTING
-# to the SettingChangeEvents set, with "DELETE_APPLICATION_SETTING" as
-# the NewValue.
-SettingChangeEvents contains {
-    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
-    "TimestampStr": Item.id.time,
-    "NewValue": NewValue,
-    "Setting": Setting,
-    "OrgUnit": OrgUnit
-}
-if {
-    some Item in input.chat_logs.items # For each item...
-    some Event in Item.events # For each event in the item...
-    Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
-
-    # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
-    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
-
-    # Extract the values
-    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
-    NewValue := "DELETE_APPLICATION_SETTING"
-    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
 
 ##############
 # GWS.CHAT.1 #
@@ -119,7 +16,7 @@ if {
 #--
 NonCompliantOUs1_1 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
+    Events := FilterEvents("ChatArchivingProto chatsDefaultToOffTheRecord", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -138,7 +35,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
+    Events := FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
     count(Events) == 0
 }
 
@@ -151,7 +48,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
+    Events := FilterEvents( "ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -162,7 +59,7 @@ if {
 #--
 NonCompliantOUs1_2 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", OU)
+    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -181,7 +78,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
+    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
     count(Events) == 0
 }
 
@@ -194,7 +91,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
+    Events := FilterEvents( "ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -210,7 +107,7 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
+    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -230,7 +127,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
+    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
     count(Events) == 0
 }
 
@@ -243,7 +140,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
+    Events := FilterEvents( "DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -258,7 +155,7 @@ if {
 #--
 NonCompliantOUs3_1 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("RoomOtrSettingsProto otr_state", OU)
+    Events := FilterEvents( "RoomOtrSettingsProto otr_state", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -277,7 +174,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
+    Events := FilterEvents( "RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) == 0
 }
 
@@ -290,7 +187,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("RoomOtrSettingsProto otr_state", TopLevelOU)
+    Events := FilterEvents( "RoomOtrSettingsProto otr_state", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -305,7 +202,7 @@ if {
 #--
 NonCompliantOUs4_1 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", OU)
+    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -324,7 +221,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
+    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) == 0
 }
 
@@ -337,7 +234,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("RestrictChatProto restrictChatToOrganization", TopLevelOU)
+    Events := FilterEvents( "RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -348,7 +245,7 @@ if {
 #--
 NonCompliantOUs4_2 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("RestrictChatProto externalChatRestriction", OU)
+    Events := FilterEvents( "RestrictChatProto externalChatRestriction", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -367,7 +264,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
+    Events := FilterEvents( "RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) == 0
 }
 
@@ -380,7 +277,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("RestrictChatProto externalChatRestriction", TopLevelOU)
+    Events := FilterEvents( "RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_2) == 0
 }
@@ -395,7 +292,7 @@ if {
 #--
 NonCompliantOUs5_1 contains OU if {
     some OU in OUsWithEvents
-    Events := FilterEventsOU("Chat app Settings - Chat apps enabled", OU)
+    Events := FilterEvents( "Chat app Settings - Chat apps enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -414,7 +311,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
+    Events := FilterEvents( "Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) == 0
 }
 
@@ -427,7 +324,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("Chat app Settings - Chat apps enabled", TopLevelOU)
+    Events := FilterEvents( "Chat app Settings - Chat apps enabled", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -8,14 +8,14 @@ FilterEvents(SettingName) := FilteredEvents if {
     FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
     FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
@@ -23,14 +23,14 @@ FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
     }
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
     FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -173,7 +173,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
+    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
     count(Events) == 0
 }
 
@@ -186,7 +186,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)    
+    Events := FilterEventsOU("ChatArchivingProto chatsDefaultToOffTheRecord", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -217,7 +217,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)    
+    Events := FilterEventsOU("ChatArchivingProto allow_chat_archiving_setting_modification", TopLevelOU)
     count(Events) == 0
 }
 
@@ -267,7 +267,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)    
+    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
     count(Events) == 0
 }
 
@@ -280,7 +280,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)      
+    Events := FilterEventsOU("DynamiteFileSharingSettingsProto external_file_sharing_setting", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -457,8 +457,7 @@ if {
     count(Events) == 0
 }
 
-tests contains 
-{
+tests contains {
     "PolicyId": "GWS.CHAT.5.1v0.1",
     "Criticality": "Shall",
     "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -1,6 +1,7 @@
 package chat
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -108,11 +109,6 @@ if {
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
-GetLastEvent(Events) := Event if {
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
-}
 
 ##############
 # GWS.CHAT.1 #

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -1,11 +1,7 @@
 package classroom
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.FilterEvents
-import data.utils.GetLastEvent
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.NoSuchEventDetails
 
 ###################
 # GWS.CLASSROOM.1 #
@@ -15,41 +11,41 @@ import data.utils.NoSuchEventDetails
 # Baseline GWS.CLASSROOM.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-   some OU in OUsWithEvents
-    Events := FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", OU)
+   some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "1"
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
 
-    Events := FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -59,40 +55,40 @@ if {
 # Baseline GWS.CLASSROOM.1.2v0.1
 #--
 NonCompliantOUs1_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "1"
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
+    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -106,13 +102,13 @@ if {
 # Baseline GWS.CLASSROOM.2.1v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ApiDataAccessSettingProto api_access_enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -120,27 +116,27 @@ NonCompliantOUs2_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CLASSROOM.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
+    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
+    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -154,13 +150,13 @@ if {
 # Baseline GWS.CLASSROOM.3.1v0.1
 #--
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("RosterImportSettingsProto sis_integrator", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "SIS_INTEGRATOR_NONE"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -168,27 +164,27 @@ NonCompliantOUs3_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CLASSROOM.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := true
-    Events := FilterEvents("RosterImportSettingsProto sis_integrator", TopLevelOU)
+    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("RosterImportSettingsProto sis_integrator", TopLevelOU)
+    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -202,13 +198,13 @@ if {
 # Baseline GWS.CLASSROOM.4.1v0.1
 #--
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "ONLY_TEACHERS_CAN_UNENROLL_STUDENTS"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -216,27 +212,27 @@ NonCompliantOUs4_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.CLASSROOM.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := true
-    Events := FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
+    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.CLASSROOM.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
+    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -202,7 +202,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) == 0
 }
@@ -216,7 +215,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
@@ -252,7 +250,6 @@ tests contains {
 }
 if {
     DefaultSafe := false
-
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) == 0
 }
@@ -266,7 +263,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -302,7 +298,6 @@ tests contains {
 }
 if {
     DefaultSafe := true
-
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) == 0
 }
@@ -316,7 +311,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
@@ -352,7 +346,6 @@ tests contains {
 }
 if {
     DefaultSafe := true
-
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) == 0
 }
@@ -366,7 +359,6 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -8,14 +8,14 @@ FilterEvents(SettingName) := FilteredEvents if {
     FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
     FilteredEvents := [
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -5,7 +5,7 @@ import data.utils.NoSuchEventDetails
 
 FilterEvents(SettingName) := FilteredEvents if {
     Events := SettingChangeEvents
-    FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
+    FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -16,11 +16,11 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [
+    FilteredEvents := {
         Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -30,7 +30,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -39,7 +39,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | some Event in Events; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 GetTopLevelOU() := name if {
@@ -86,9 +86,9 @@ if {
     some Event in Item.events # For each event in the item...
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | some Parameter in Event.parameters]
-    "NEW_VALUE" in [Parameter.name | some Parameter in Event.parameters]
-    "ORG_UNIT_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
@@ -114,8 +114,8 @@ if {
     Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | some Parameter in Event.parameters]
-    "ORG_UNIT_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
@@ -124,7 +124,7 @@ if {
 }
 
 GetLastEvent(Events) := Event if {
-    MaxTs := max([Event.Timestamp | some Event in Events])
+    MaxTs := max({Event.Timestamp | some Event in Events})
     some Event in Events
     Event.Timestamp == MaxTs
 }

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -42,14 +42,14 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Simplest case: if input.tenant_info.topLevelOU is
     # non-empty, it contains the name of the top-level OU.
     input.tenant_info.topLevelOU != ""
-    name := input.tenant_info.topLevelOU
+    Name := input.tenant_info.topLevelOU
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # input.tenant_info.topLevelOU will be empty when
     # no custom OUs have been created, as in this case
     # the top-level OU cannot be determined via the API.
@@ -58,16 +58,16 @@ GetTopLevelOU() := name if {
     # the events and know that it is the top-level OU
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) > 0
-    name := GetLastEvent(SettingChangeEvents).OrgUnit
+    Name := GetLastEvent(SettingChangeEvents).OrgUnit
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Extreme edge case: no custom OUs have been made
     # and the logs are empty. In this case, we really
     # have no way of determining the top-level OU name.
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
-    name := ""
+    Name := ""
 }
 
 OUsWithEvents contains Event.OrgUnit if {
@@ -157,7 +157,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
     count(Events) == 0
 }
@@ -171,7 +171,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
@@ -202,7 +202,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) == 0
 }
@@ -216,7 +216,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
@@ -252,7 +252,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) == 0
 }
@@ -266,7 +266,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -302,7 +302,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) == 0
 }
@@ -316,7 +316,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
@@ -352,7 +352,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) == 0
 }
@@ -366,7 +366,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    TopLevelOU := GetTopLevelOU()
+
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -3,6 +3,8 @@ package classroom
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("classroom_logs")
+
 ###################
 # GWS.CLASSROOM.1 #
 ###################
@@ -12,7 +14,7 @@ import future.keywords
 #--
 NonCompliantOUs1_1 contains OU if {
    some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", OU)
+    Events := utils.FilterEvents(LogEvents, "ClassMembershipSettingsGroup who_can_join_classes", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -31,7 +33,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -45,7 +47,7 @@ tests contains {
 }
 if {
 
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ClassMembershipSettingsGroup who_can_join_classes", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -56,7 +58,7 @@ if {
 #--
 NonCompliantOUs1_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", OU)
+    Events := utils.FilterEvents(LogEvents, "ClassMembershipSettingsGroup which_classes_can_users_join", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -75,7 +77,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", utils.TopLevelOU)
+    SettingName := "ClassMembershipSettingsGroup which_classes_can_users_join"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -88,7 +91,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ClassMembershipSettingsGroup which_classes_can_users_join", utils.TopLevelOU)
+    SettingName := "ClassMembershipSettingsGroup which_classes_can_users_join"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -103,7 +107,7 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", OU)
+    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -123,7 +127,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -136,7 +140,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -151,7 +155,7 @@ if {
 #--
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", OU)
+    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -171,7 +175,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -184,7 +188,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -199,7 +203,7 @@ if {
 #--
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
+    Events := utils.FilterEvents(LogEvents, "StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -219,7 +223,8 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", utils.TopLevelOU)
+    SettingName := "StudentUnenrollmentSettingsProto who_can_unenroll_students"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -232,7 +237,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("StudentUnenrollmentSettingsProto who_can_unenroll_students", utils.TopLevelOU)
+    SettingName := "StudentUnenrollmentSettingsProto who_can_unenroll_students"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -133,13 +133,9 @@ GetLastEvent(Events) := Event if {
 # GWS.CLASSROOM.1 #
 ###################
 
-
 #
 # Baseline GWS.CLASSROOM.1.1v0.1
 #--
-
-#No OU to Inherit
-
 NonCompliantOUs1_1 contains OU if {
    some OU in OUsWithEvents
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", OU)
@@ -185,7 +181,6 @@ if {
 #
 # Baseline GWS.CLASSROOM.1.2v0.1
 #--
-
 NonCompliantOUs1_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", OU)
@@ -235,7 +230,6 @@ if {
 #
 # Baseline GWS.CLASSROOM.2.1v0.1
 #--
-
 NonCompliantOUs2_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", OU)
@@ -286,7 +280,6 @@ if {
 #
 # Baseline GWS.CLASSROOM.3.1v0.1
 #--
-
 NonCompliantOUs3_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", OU)
@@ -330,8 +323,6 @@ if {
 }
 #--
 
-#--
-
 ###################
 # GWS.CLASSROOM.4 #
 ###################
@@ -339,7 +330,6 @@ if {
 #
 # Baseline GWS.CLASSROOM.4.1v0.1
 #--
-
 NonCompliantOUs4_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
@@ -350,7 +340,6 @@ NonCompliantOUs4_1 contains OU if {
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "ONLY_TEACHERS_CAN_UNENROLL_STUDENTS"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
-
 }
 
 tests contains {

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -1,5 +1,6 @@
 package classroom
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -41,34 +42,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -1,6 +1,7 @@
 package classroom
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -93,11 +94,6 @@ if {
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
-GetLastEvent(Events) := Event if {
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
-}
 
 ###################
 # GWS.CLASSROOM.1 #

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -70,16 +70,18 @@ GetTopLevelOU() := name if {
     name := ""
 }
 
-OUsWithEvents[Event.OrgUnit] {
+OUsWithEvents contains Event.OrgUnit if {
     some Event in SettingChangeEvents
 }
 
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
+    "OrgUnit": OrgUnit
+}
+if {
     some Item in input.classroom_logs.items # For each item...
     some Event in Item.events # For each event in the item...
 
@@ -99,12 +101,14 @@ SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
 # minimal special logic, this rule adds the DELETE_APPLICATION_SETTING
 # to the SettingChangeEvents set, with "DELETE_APPLICATION_SETTING" as
 # the NewValue.
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
+    "OrgUnit": OrgUnit
+}
+if {
     some Item in input.classroom_logs.items # For each item...
     some Event in Item.events # For each event in the item...
     Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
@@ -136,7 +140,7 @@ GetLastEvent(Events) := Event if {
 
 #No OU to Inherit
 
-NonCompliantOUs1_1[OU] {
+NonCompliantOUs1_1 contains OU if {
    some OU in OUsWithEvents
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
@@ -147,24 +151,30 @@ NonCompliantOUs1_1[OU] {
     LastEvent.NewValue != "1"
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.1.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.1.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.1.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.1.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ClassMembershipSettingsGroup who_can_join_classes", TopLevelOU)
     count(Events) > 0
@@ -176,8 +186,8 @@ tests[{ "PolicyId": "GWS.CLASSROOM.1.1v0.1",
 # Baseline GWS.CLASSROOM.1.2v0.1
 #--
 
-NonCompliantOUs1_2[OU] {
-   some OU in OUsWithEvents
+NonCompliantOUs1_2 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -187,24 +197,30 @@ NonCompliantOUs1_2[OU] {
     LastEvent.NewValue != "1"
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.1.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.1.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.1.2v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.1.2v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ClassMembershipSettingsGroup which_classes_can_users_join", TopLevelOU)
     count(Events) > 0
@@ -220,8 +236,8 @@ tests[{ "PolicyId": "GWS.CLASSROOM.1.2v0.1",
 # Baseline GWS.CLASSROOM.2.1v0.1
 #--
 
-NonCompliantOUs2_1[OU] {
-   some OU in OUsWithEvents
+NonCompliantOUs2_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -232,24 +248,30 @@ NonCompliantOUs2_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.2.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.2.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("ApiDataAccessSettingProto api_access_enabled", TopLevelOU)
     count(Events) > 0
@@ -265,8 +287,8 @@ tests[{ "PolicyId": "GWS.CLASSROOM.2.1v0.1",
 # Baseline GWS.CLASSROOM.3.1v0.1
 #--
 
-NonCompliantOUs3_1[OU] {
-   some OU in OUsWithEvents
+NonCompliantOUs3_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -277,24 +299,30 @@ NonCompliantOUs3_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.3.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := true
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.3.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("RosterImportSettingsProto sis_integrator", TopLevelOU)
     count(Events) > 0
@@ -312,8 +340,8 @@ tests[{ "PolicyId": "GWS.CLASSROOM.3.1v0.1",
 # Baseline GWS.CLASSROOM.4.1v0.1
 #--
 
-NonCompliantOUs4_1[OU] {
-   some OU in OUsWithEvents
+NonCompliantOUs4_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -325,24 +353,30 @@ NonCompliantOUs4_1[OU] {
 
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.4.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := true
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.CLASSROOM.4.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}]{
+tests contains {
+    "PolicyId": "GWS.CLASSROOM.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("StudentUnenrollmentSettingsProto who_can_unenroll_students", TopLevelOU)
     count(Events) > 0

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -1,5 +1,6 @@
 package classroom
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -68,10 +69,6 @@ TopLevelOU := Name if {
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
     Name := ""
-}
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
 }
 
 SettingChangeEvents contains {

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -1,13 +1,7 @@
 package commoncontrols
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.FilterEvents
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.FilterEventsNoOU
-import data.utils.NoSuchEventDetails
-import data.utils.ReportDetailsBoolean
 
 FilterEventsAlt(EventName) := Events if {
     # Many of the events for common controls are structured differently.
@@ -88,37 +82,37 @@ if {
 # two different settings simultaneously.
 NoSuchEvent1_1 := true if {
     # No such event...
-    Events := FilterEventsAltOU("ENFORCE_STRONG_AUTHENTICATION", TopLevelOU)
+    Events := FilterEventsAltOU("ENFORCE_STRONG_AUTHENTICATION", utils.TopLevelOU)
     count(Events) == 0
 }
 
 NoSuchEvent1_1 := true if {
     # No such event...
-    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 default NoSuchEvent1_1 := false
 
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("ENFORCE_STRONG_AUTHENTICATION", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
 }
 
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "ONLY_SECURITY_KEY"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -126,7 +120,7 @@ NonCompliantOUs1_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -139,7 +133,7 @@ if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -155,13 +149,13 @@ if {
 #--
 
 NonCompliantOUs1_2 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "1 week"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -169,27 +163,27 @@ NonCompliantOUs1_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_ENROLLMENT_PERIOD_DURATION", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -200,13 +194,13 @@ if {
 #--
 
 NonCompliantOUs1_3 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_FREQUENCY", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DISABLE_USERS_TO_TRUST_DEVICE"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -214,27 +208,27 @@ NonCompliantOUs1_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_FREQUENCY", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_FREQUENCY", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_FREQUENCY", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_TWO_STEP_VERIFICATION_FREQUENCY", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_3) == 0
 }
@@ -245,40 +239,40 @@ if {
 #--
 
 NonCompliantOUs1_4 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ANY"
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.1.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", TopLevelOU)
+    Events := FilterEventsAltOU("CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_4) == 0
 }
@@ -302,7 +296,7 @@ tests contains {
         "No relevant event in the current logs. While we are unable ",
         "to determine the state from the logs, the default setting ",
         "is non-compliant; manual check recommended."
-    ]), # Custom message instead of NoSuchEventDetails function,
+    ]), # Custom message instead of utils.NoSuchEventDetails function,
     # as this setting isn't controlled at the OU level
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
@@ -317,7 +311,7 @@ if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsBoolean(Status),
+    "ReportDetails": utils.ReportDetailsBoolean(Status),
     "ActualValue": {"TOGGLE_CAA_ENABLEMENT": LastEvent.NewValue},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -325,7 +319,7 @@ tests contains {
 if {
     Events := FilterEventsAlt("TOGGLE_CAA_ENABLEMENT")
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "ENABLED"
 }
 #--
@@ -352,13 +346,13 @@ tests contains {
 #--
 
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SsoPolicyProto challenge_selection_behavior", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "PERFORM_CHALLENGE_SELECTION"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -366,27 +360,27 @@ NonCompliantOUs3_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SsoPolicyProto challenge_selection_behavior", TopLevelOU)
+    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SsoPolicyProto challenge_selection_behavior", TopLevelOU)
+    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -411,13 +405,13 @@ IsGoodLimit(ActualLim) := false if {
 }
 
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Session management settings - Session length in seconds", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Session management settings - Session length in seconds", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
     not IsGoodLimit(LastEvent.NewValue)
 }
@@ -425,27 +419,27 @@ NonCompliantOUs4_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Session management settings - Session length in seconds", TopLevelOU)
+    Events := utils.FilterEvents("Session management settings - Session length in seconds", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Session management settings - Session length in seconds", TopLevelOU)
+    Events := utils.FilterEvents("Session management settings - Session length in seconds", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -460,13 +454,13 @@ if {
 #--
 
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Password Management - Enforce strong password", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Password Management - Enforce strong password", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "on"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -474,26 +468,26 @@ NonCompliantOUs5_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Password Management - Enforce strong password", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enforce strong password", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 } if {
-    Events := FilterEvents("Password Management - Enforce strong password", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enforce strong password", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -504,13 +498,13 @@ tests contains {
 #--
 
 NonCompliantOUs5_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Password Management - Minimum password length", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Password Management - Minimum password length", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
     Minimum := to_number(LastEvent.NewValue)
     Minimum < 12
@@ -519,27 +513,27 @@ NonCompliantOUs5_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Password Management - Minimum password length", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Minimum password length", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Password Management - Minimum password length", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Minimum password length", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_2) == 0
 }
@@ -550,13 +544,13 @@ if {
 #--
 
 NonCompliantOUs5_3 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Password Management - Enforce password policy at next login", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "true"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -564,27 +558,27 @@ NonCompliantOUs5_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Password Management - Enforce password policy at next login", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Password Management - Enforce password policy at next login", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_3) == 0
 }
@@ -595,13 +589,13 @@ if {
 #--
 
 NonCompliantOUs5_4 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Password Management - Enable password reuse", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Password Management - Enable password reuse", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -609,27 +603,27 @@ NonCompliantOUs5_4 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Password Management - Enable password reuse", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enable password reuse", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Password Management - Enable password reuse", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Enable password reuse", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_4) == 0
 }
@@ -640,13 +634,13 @@ if {
 #--
 
 NonCompliantOUs5_5 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Password Management - Password reset frequency", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Password Management - Password reset frequency", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "0"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -654,27 +648,27 @@ NonCompliantOUs5_5 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Password Management - Password reset frequency", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Password reset frequency", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.5.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_5),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Password Management - Password reset frequency", TopLevelOU)
+    Events := utils.FilterEvents("Password Management - Password reset frequency", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_5) == 0
 }
@@ -778,13 +772,13 @@ tests contains {
 #--
 
 NonCompliantOUs9_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -792,26 +786,26 @@ NonCompliantOUs9_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.9.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", TopLevelOU)
+    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.9.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs9_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs9_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs9_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 } if {
-    Events := FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", TopLevelOU)
+    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_2) == 0
 }
@@ -939,7 +933,7 @@ HighRiskBlocked contains Service if {
     # Filter for just that service
     FilteredEvents := {Event | some Event in APIAccessEvents; Event.ServiceName == Service}
     # Get the most recent change
-    Event := GetLastEvent(FilteredEvents)
+    Event := utils.GetLastEvent(FilteredEvents)
     # If the most recent change is ALLOW, this service is unrestricted
     Event.EventName == "DISALLOW_SERVICE_FOR_OAUTH2_ACCESS"
 }
@@ -954,7 +948,7 @@ UnrestrictedServices11_2 contains Service if {
     # Filter for just that service
     FilteredEvents := {Event | some Event in APIAccessEvents; Event.ServiceName == Service}
     # Get the most recent change
-    Event := GetLastEvent(FilteredEvents)
+    Event := utils.GetLastEvent(FilteredEvents)
     # If the most recent change is ALLOW... and the _HIGH_RISK
     # version of the service is not blocked, then the app is unrestricted
     Event.EventName == "ALLOW_SERVICE_FOR_OAUTH2_ACCESS"
@@ -1017,7 +1011,7 @@ UnrestrictedServices11_3 contains Service if {
     # Filter for just that service
     FilteredEvents := {Event | some Event in APIAccessEvents; Event.ServiceName == Service}
     # Get the most recent change
-    Event := GetLastEvent(FilteredEvents)
+    Event := utils.GetLastEvent(FilteredEvents)
     # If the most recent change is ALLOW..., even if the _HIGH_RISK
     # version of the service is blocked, then the app is unrestricted
     # for the purposes of 11.3, so we don't need to check the high
@@ -1086,40 +1080,40 @@ if {
 }
 
 NonCompliantOUs11_4 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := {Event | some Event in DomainOwnedAppAccessEvents; Event.OrgUnit == OU}
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.EventName != "UNTRUST_DOMAIN_OWNED_OAUTH2_APPS"
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.11.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := {Event | some Event in DomainOwnedAppAccessEvents; Event.OrgUnit == TopLevelOU}
+    Events := {Event | some Event in DomainOwnedAppAccessEvents; Event.OrgUnit == utils.TopLevelOU}
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.11.4v0.1",
         "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs11_4),
+        "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs11_4),
         "ActualValue": {"NonCompliantOUs": NonCompliantOUs11_4},
         "RequirementMet": Status,
         "NoSuchEvent": false
 }
 if {
-    Events := {Event | some Event in DomainOwnedAppAccessEvents; Event.OrgUnit == TopLevelOU}
+    Events := {Event | some Event in DomainOwnedAppAccessEvents; Event.OrgUnit == utils.TopLevelOU}
     count(Events) > 0
     Status := count(NonCompliantOUs11_4) == 0
 }
@@ -1148,40 +1142,40 @@ if {
 }
 
 NonCompliantOUs11_5 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := [Event | some Event in UnconfiguredAppAccessEvents; Event.OrgUnit == OU]
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.EventName != "BLOCK_ALL_THIRD_PARTY_API_ACCESS"
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.11.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := {Event | some Event in UnconfiguredAppAccessEvents; Event.OrgUnit == TopLevelOU}
+    Events := {Event | some Event in UnconfiguredAppAccessEvents; Event.OrgUnit == utils.TopLevelOU}
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.11.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs11_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs11_5),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs11_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := {Event | some Event in UnconfiguredAppAccessEvents; Event.OrgUnit == TopLevelOU}
+    Events := {Event | some Event in UnconfiguredAppAccessEvents; Event.OrgUnit == utils.TopLevelOU}
     count(Events) > 0
     Status := count(NonCompliantOUs11_5) == 0
 }
@@ -1216,37 +1210,37 @@ tests contains {
 # Custom NoSuchEvent function needed as we're checking
 # two different settings simultaneously.
 NoSuchEvent12_2 := true if {
-    Events := FilterEvents("Apps Access Setting Allowlist access", TopLevelOU)
+    Events := utils.FilterEvents("Apps Access Setting Allowlist access", utils.TopLevelOU)
     count(Events) == 0
 }
 
 NoSuchEvent12_2 := true if {
-    Events := FilterEvents("Apps Access Setting allow_all_internal_apps", TopLevelOU)
+    Events := utils.FilterEvents("Apps Access Setting allow_all_internal_apps", utils.TopLevelOU)
     count(Events) == 0
 }
 
 default NoSuchEvent12_2 := false
 
 NonCompliantOUs12_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Apps Access Setting Allowlist access", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Apps Access Setting Allowlist access", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "ALLOW_SPECIFIED"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
 NonCompliantOUs12_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Apps Access Setting allow_all_internal_apps", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Apps Access Setting allow_all_internal_apps", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -1254,7 +1248,7 @@ NonCompliantOUs12_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.12.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -1267,7 +1261,7 @@ if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.12.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs12_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs12_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs12_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -1288,13 +1282,13 @@ if {
 #--
 
 NonCompliantOUs13_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsAltOU("WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DENIED"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -1308,27 +1302,27 @@ NonCompliantOUs13_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.13.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsAltOU("WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED", TopLevelOU)
+    Events := FilterEventsAltOU("WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.13.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs13_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs13_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs13_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsAltOU("WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED", TopLevelOU)
+    Events := FilterEventsAltOU("WEAK_PROGRAMMATIC_LOGIN_SETTINGS_CHANGED", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs13_1) == 0
 }
@@ -1342,20 +1336,20 @@ Apps := {"Blogger", "Google Books", "Google Pay", "Google Photos", "Google Play"
     "Google Play Console", "Location History", "YouTube"}
 
 AppsAllowingTakoutOU contains App {
-    Events := FilterEventsNoOU("UserTakeoutSettingsProto User Takeout ")
+    Events := utils.FilterEventsNoOU("UserTakeoutSettingsProto User Takeout ")
     some App in Apps
     Filtered := {Event | some Event in Events; Event.AppName == App; Event.OrgUnit == data.OrgUnit}
     # Note the data.OrgUnit. This means this
     # rule will only work if called like this:
     # AppsAllowingTakoutOU with data.OrgUnit as ExampleOrgUnit
-    LastEvent := GetLastEvent(Filtered)
+    LastEvent := utils.GetLastEvent(Filtered)
     LastEvent.NewValue != "Disabled"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
 NonCompliantOUs14_1 contains OU {
-    some OU in OUsWithEvents
-    Events := FilterEvents("UserTakeoutSettingsProto User Takeout ", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1373,7 +1367,7 @@ tests contains {
     "Criticality": "Shall",
     "ReportDetails": concat("", [
         "For apps with individual admin control: ",
-        NoSuchEventDetails(DefaultSafe, TopLevelOU)
+        utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU)
     ]),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
@@ -1381,7 +1375,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := FilterEvents("UserTakeoutSettingsProto User Takeout ", TopLevelOU)
+    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1390,14 +1384,14 @@ tests contains {
     "Criticality": "Shall",
     "ReportDetails": concat("", [
         "For apps with individual admin control: ",
-        ReportDetailsOUs(NonCompliantOUs14_1)
+        utils.ReportDetailsOUs(NonCompliantOUs14_1)
     ]),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs14_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("UserTakeoutSettingsProto User Takeout ", TopLevelOU)
+    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs14_1) == 0
 }
@@ -1445,40 +1439,42 @@ tests contains {
 #--
 
 NonCompliantOUs16_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Data Sharing Settings between GCP and Google Workspace \"Sharing Options\"", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Data Sharing Settings between GCP and Google Workspace \"Sharing Options\"", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "ENABLED"
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.16.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Data Sharing Settings between GCP and Google Workspace \"Sharing Options\"", TopLevelOU)
+    SettingName := "Data Sharing Settings between GCP and Google Workspace \"Sharing Options\""
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.16.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs16_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs16_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs16_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Data Sharing Settings between GCP and Google Workspace \"Sharing Options\"", TopLevelOU)
+    SettingName := "Data Sharing Settings between GCP and Google Workspace \"Sharing Options\""
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs16_1) == 0
 }
@@ -1524,40 +1520,40 @@ tests contains {
 #--
 
 NonCompliantOUs18_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.18.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", TopLevelOU)
+    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.COMMONCONTROLS.18.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs18_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs18_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs18_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", TopLevelOU)
+    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs18_1) == 0
 }

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -65,6 +65,7 @@ if {
     OrgUnit := GetEventOu(Event)
 }
 
+LogEvents := utils.GetEvents("commoncontrols_logs")
 
 ########################
 # GWS.COMMONCONTROLS.1 #
@@ -347,7 +348,7 @@ tests contains {
 
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", OU)
+    Events := utils.FilterEvents(LogEvents, "SsoPolicyProto challenge_selection_behavior", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -367,7 +368,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -380,7 +381,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SsoPolicyProto challenge_selection_behavior", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -406,7 +407,7 @@ IsGoodLimit(ActualLim) := false if {
 
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Session management settings - Session length in seconds", OU)
+    Events := utils.FilterEvents(LogEvents, "Session management settings - Session length in seconds", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -426,7 +427,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Session management settings - Session length in seconds", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Session management settings - Session length in seconds", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -439,7 +440,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Session management settings - Session length in seconds", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Session management settings - Session length in seconds", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -455,7 +456,7 @@ if {
 
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Password Management - Enforce strong password", OU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enforce strong password", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -475,7 +476,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Password Management - Enforce strong password", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enforce strong password", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -487,7 +488,7 @@ tests contains {
     "RequirementMet": Status,
     "NoSuchEvent": false
 } if {
-    Events := utils.FilterEvents("Password Management - Enforce strong password", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enforce strong password", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -499,7 +500,7 @@ tests contains {
 
 NonCompliantOUs5_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Password Management - Minimum password length", OU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Minimum password length", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -520,7 +521,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Password Management - Minimum password length", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Minimum password length", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -533,7 +534,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Password Management - Minimum password length", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Minimum password length", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_2) == 0
 }
@@ -545,7 +546,7 @@ if {
 
 NonCompliantOUs5_3 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", OU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enforce password policy at next login", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -565,7 +566,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", utils.TopLevelOU)
+    SettingName := "Password Management - Enforce password policy at next login"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -578,7 +580,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Password Management - Enforce password policy at next login", utils.TopLevelOU)
+    SettingName := "Password Management - Enforce password policy at next login"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_3) == 0
 }
@@ -590,7 +593,7 @@ if {
 
 NonCompliantOUs5_4 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Password Management - Enable password reuse", OU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enable password reuse", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -610,7 +613,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Password Management - Enable password reuse", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enable password reuse", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -623,7 +626,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Password Management - Enable password reuse", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Enable password reuse", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_4) == 0
 }
@@ -635,7 +638,7 @@ if {
 
 NonCompliantOUs5_5 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Password Management - Password reset frequency", OU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Password reset frequency", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -655,7 +658,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Password Management - Password reset frequency", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Password reset frequency", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -668,7 +671,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Password Management - Password reset frequency", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Password Management - Password reset frequency", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_5) == 0
 }
@@ -773,7 +776,7 @@ tests contains {
 
 NonCompliantOUs9_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", OU)
+    Events := utils.FilterEvents(LogEvents, "AdminAccountRecoverySettingsProto Enable admin account recovery", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -793,7 +796,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", utils.TopLevelOU)
+    SettingName := "AdminAccountRecoverySettingsProto Enable admin account recovery"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -805,7 +809,8 @@ tests contains {
     "RequirementMet": Status,
     "NoSuchEvent": false
 } if {
-    Events := utils.FilterEvents("AdminAccountRecoverySettingsProto Enable admin account recovery", utils.TopLevelOU)
+    SettingName := "AdminAccountRecoverySettingsProto Enable admin account recovery"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_2) == 0
 }
@@ -1210,12 +1215,12 @@ tests contains {
 # Custom NoSuchEvent function needed as we're checking
 # two different settings simultaneously.
 NoSuchEvent12_2 := true if {
-    Events := utils.FilterEvents("Apps Access Setting Allowlist access", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Apps Access Setting Allowlist access", utils.TopLevelOU)
     count(Events) == 0
 }
 
 NoSuchEvent12_2 := true if {
-    Events := utils.FilterEvents("Apps Access Setting allow_all_internal_apps", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Apps Access Setting allow_all_internal_apps", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1223,7 +1228,7 @@ default NoSuchEvent12_2 := false
 
 NonCompliantOUs12_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Apps Access Setting Allowlist access", OU)
+    Events := utils.FilterEvents(LogEvents, "Apps Access Setting Allowlist access", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1235,7 +1240,7 @@ NonCompliantOUs12_2 contains OU if {
 
 NonCompliantOUs12_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Apps Access Setting allow_all_internal_apps", OU)
+    Events := utils.FilterEvents(LogEvents, "Apps Access Setting allow_all_internal_apps", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1336,7 +1341,7 @@ Apps := {"Blogger", "Google Books", "Google Pay", "Google Photos", "Google Play"
     "Google Play Console", "Location History", "YouTube"}
 
 AppsAllowingTakoutOU contains App {
-    Events := utils.FilterEventsNoOU("UserTakeoutSettingsProto User Takeout ")
+    Events := utils.FilterEventsNoOU(LogEvents, "UserTakeoutSettingsProto User Takeout ")
     some App in Apps
     Filtered := {Event | some Event in Events; Event.AppName == App; Event.OrgUnit == data.OrgUnit}
     # Note the data.OrgUnit. This means this
@@ -1349,7 +1354,7 @@ AppsAllowingTakoutOU contains App {
 
 NonCompliantOUs14_1 contains OU {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", OU)
+    Events := utils.FilterEvents(LogEvents, "UserTakeoutSettingsProto User Takeout ", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1375,7 +1380,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1391,7 +1396,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "UserTakeoutSettingsProto User Takeout ", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs14_1) == 0
 }
@@ -1440,7 +1445,8 @@ tests contains {
 
 NonCompliantOUs16_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Data Sharing Settings between GCP and Google Workspace \"Sharing Options\"", OU)
+    SettingName := "Data Sharing Settings between GCP and Google Workspace \"Sharing Options\""
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1460,7 +1466,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Data Sharing Settings between GCP and Google Workspace \"Sharing Options\""
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1474,7 +1480,7 @@ tests contains {
 }
 if {
     SettingName := "Data Sharing Settings between GCP and Google Workspace \"Sharing Options\""
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs16_1) == 0
 }
@@ -1521,7 +1527,7 @@ tests contains {
 
 NonCompliantOUs18_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", OU)
+    Events := utils.FilterEvents(LogEvents, "CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1540,7 +1546,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1553,7 +1559,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "CHANGE_DATA_LOCALIZATION_FOR_RUSSIA", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs18_1) == 0
 }

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -1,5 +1,6 @@
 package commoncontrols
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -218,18 +219,6 @@ TopLevelOU := Name if {
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
     Name := ""
-}
-
-# The simpler version of OUsWithEvents won't work
-# here because common controls has the two alt SettingChangeEvents
-# rules, which means the simpler version might not find all OUs that
-# have an event.
-#
-OUsWithEvents contains OrgUnit if {
-    some Item in input.commoncontrols_logs.items
-    some Event in Item.events
-    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
-    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
 ########################

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -1,5 +1,6 @@
 package commoncontrols
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -193,33 +194,6 @@ if {
     OrgUnit := GetEventOu(Event)
 }
 
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
-}
 
 ########################
 # GWS.COMMONCONTROLS.1 #

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -1,6 +1,7 @@
 package commoncontrols
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -124,12 +125,6 @@ if {
     # Extract the values
     NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-GetLastEvent(Events) := Event if {
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 FilterEventsAlt(EventName) := Events if {

--- a/rego/Commoncontrols.rego
+++ b/rego/Commoncontrols.rego
@@ -1340,7 +1340,7 @@ if {
 Apps := {"Blogger", "Google Books", "Google Pay", "Google Photos", "Google Play",
     "Google Play Console", "Location History", "YouTube"}
 
-AppsAllowingTakoutOU contains App {
+AppsAllowingTakoutOU contains App if {
     Events := utils.FilterEventsNoOU(LogEvents, "UserTakeoutSettingsProto User Takeout ")
     some App in Apps
     Filtered := {Event | some Event in Events; Event.AppName == App; Event.OrgUnit == data.OrgUnit}
@@ -1352,7 +1352,7 @@ AppsAllowingTakoutOU contains App {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-NonCompliantOUs14_1 contains OU {
+NonCompliantOUs14_1 contains OU if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "UserTakeoutSettingsProto User Takeout ", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -3,6 +3,8 @@ package drive
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("drive_logs")
+
 ###################
 # GWS.DRIVEDOCS.1 #
 ###################
@@ -13,7 +15,7 @@ import future.keywords
 # TODO: OU inheritence implementation pending after SCB updates, refer to #328
 NonCompliantOUs1_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     SettingValue := "SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT"
@@ -30,7 +32,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -43,7 +45,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -54,7 +56,7 @@ if {
 #--
 NonCompliantOUs1_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("SHARING_NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
@@ -70,7 +72,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -83,7 +85,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -94,7 +96,7 @@ if {
 #--
 NonCompliantOUs1_3 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("SHARING_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == true
@@ -110,7 +112,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -123,7 +125,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_3) == 0
 }
@@ -134,7 +136,7 @@ if {
 #--
 NonCompliantOUs1_4 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
@@ -150,7 +152,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -163,7 +165,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_4) == 0
 }
@@ -174,7 +176,7 @@ if {
 #--
 NonCompliantOUs1_5 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("PUBLISHING_TO_WEB", OU)
+    Events := utils.FilterEvents(LogEvents, "PUBLISHING_TO_WEB", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("ALLOWED", LastEvent.NewValue) == true
@@ -190,7 +192,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("PUBLISHING_TO_WEB", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "PUBLISHING_TO_WEB", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -203,7 +205,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("PUBLISHING_TO_WEB", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "PUBLISHING_TO_WEB", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_5) == 0
 }
@@ -214,7 +216,7 @@ if {
 #--
 NonCompliantOUs1_6 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_ACCESS_CHECKER_OPTIONS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("NAMED_PARTIES_ONLY DOMAIN_OR_NAMED_PARTIES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
@@ -230,7 +232,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS",utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_ACCESS_CHECKER_OPTIONS",utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -243,7 +245,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_ACCESS_CHECKER_OPTIONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_6) == 0
 }
@@ -254,7 +256,7 @@ if {
 #--
 NonCompliantOUs1_7 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     SettingValue := "CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT"
@@ -271,7 +273,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -284,7 +286,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_7) == 0
 }
@@ -295,7 +297,7 @@ if {
 #--
 NonCompliantOUs1_8 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
+    Events := utils.FilterEvents(LogEvents, "DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "PRIVATE"
@@ -312,7 +314,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "DEFAULT_LINK_SHARING_FOR_NEW_DOCS",utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -325,7 +327,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "DEFAULT_LINK_SHARING_FOR_NEW_DOCS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_8) == 0
 }
@@ -340,7 +342,7 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", OU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation CanCreateSharedDrives", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
@@ -357,7 +359,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -370,7 +372,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -381,7 +383,7 @@ if {
 #--
 NonCompliantOUs2_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", OU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_admin_only", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
@@ -398,7 +400,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -411,7 +413,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_2) == 0
 }
@@ -422,7 +424,7 @@ if {
 #--
 NonCompliantOUs2_3 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
@@ -439,7 +441,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", utils.TopLevelOU)
+    SettingName := "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -452,7 +455,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", utils.TopLevelOU)
+    SettingName := "Shared Drive Creation new_team_drive_restricts_cross_domain_access"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_3) == 0
 }
@@ -463,7 +467,7 @@ if {
 #--
 NonCompliantOUs2_4 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", OU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_restricts_direct_access", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
@@ -480,7 +484,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", utils.TopLevelOU)
+    SettingName := "Shared Drive Creation new_team_drive_restricts_direct_access"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -493,7 +498,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", utils.TopLevelOU)
+    SettingName := "Shared Drive Creation new_team_drive_restricts_direct_access"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_4) == 0
 }
@@ -504,7 +510,7 @@ if {
 #--
 NonCompliantOUs2_5 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", OU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_restricts_download", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     contains("false", LastEvent.NewValue) == false
@@ -521,7 +527,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -534,7 +540,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_5) == 0
 }
@@ -550,13 +556,14 @@ if {
 #--
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events_A := utils.FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU)
+    SettingName := "Link Security Update Settings allow_less_secure_link_user_restore"
+    Events_A := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events_A) == 0
 }
 
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events := utils.FilterEvents("Link Security Update Settings less_secure_link_option", TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "Link Security Update Settings less_secure_link_option", TopLevelOU)
     count(Events) == 0
 }
 
@@ -564,11 +571,11 @@ default NoSuchEvent3_1(_) := false
 
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events_A := utils.FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", OU)
+    Events_A := utils.FilterEvents(LogEvents, "Link Security Update Settings allow_less_secure_link_user_restore", OU)
     count(Events_A) > 0
     LastEvent_A := utils.GetLastEvent(Events_A)
 
-    Events_B := utils.FilterEvents("Link Security Update Settings less_secure_link_option", OU)
+    Events_B := utils.FilterEvents(LogEvents, "Link Security Update Settings less_secure_link_option", OU)
     count(Events_B) > 0
     LastEvent_B := utils.GetLastEvent(Events_B)
 
@@ -614,7 +621,7 @@ if {
 #--
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DRIVE_APPS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
@@ -631,7 +638,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DRIVE_APPS", utils.TopLevelOU)
     count(Events) == 0
 
 }
@@ -645,7 +652,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DRIVE_APPS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -661,7 +668,7 @@ if {
 #--
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DOCS_ADD_ONS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
@@ -678,7 +685,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
     count(Events) == 0
 
 }
@@ -692,7 +699,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -708,24 +715,24 @@ if {
 default NoSuchEvent6_1(_) := true
 
 NoSuchEvent6_1(TopLevelOU) := false if {
-    Events := utils.FilterEvents("DriveFsSettingsProto drive_fs_enabled", TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "DriveFsSettingsProto drive_fs_enabled", TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent6_1(TopLevelOU) := false if {
     # No such event...
-    Events := utils.FilterEvents("DriveFsSettingsProto company_owned_only_enabled", TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "DriveFsSettingsProto company_owned_only_enabled", TopLevelOU)
     count(Events) != 0
 }
 
 NonCompliantOUs6_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events_A := utils.FilterEvents("DriveFsSettingsProto drive_fs_enabled", OU)
+    Events_A := utils.FilterEvents(LogEvents, "DriveFsSettingsProto drive_fs_enabled", OU)
     count(Events_A) > 0
     LastEvent_A := utils.GetLastEvent(Events_A)
     LastEvent_A.NewValue != "DELETE_APPLICATION_SETTING"
 
-    Events_B := utils.FilterEvents("DriveFsSettingsProto company_owned_only_enabled", OU)
+    Events_B := utils.FilterEvents(LogEvents, "DriveFsSettingsProto company_owned_only_enabled", OU)
     count(Events_B) > 0
     LastEvent_B := utils.GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -1,5 +1,6 @@
 package drive
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.NoSuchEventDetails
 import data.utils.ReportDetailsOUs
@@ -42,34 +43,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -142,7 +142,7 @@ GetLastEvent(Events) := Event if {
 #--
 # TODO: OU inheritence implementation pending after SCB updates, refer to #328
 NonCompliantOUs1_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -176,7 +176,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
 # Baseline GWS.DRIVEDOCS.1.2v0.1
 #--
 NonCompliantOUs1_2[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -210,7 +210,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
 # Baseline GWS.DRIVEDOCS.1.3v0.1
 #--
 NonCompliantOUs1_3[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -244,7 +244,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
 # Baseline GWS.DRIVEDOCS.1.4v0.1
 #--
 NonCompliantOUs1_4[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -278,7 +278,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
 # Baseline GWS.DRIVEDOCS.1.5v0.1
 #--
 NonCompliantOUs1_5[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("PUBLISHING_TO_WEB", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -312,7 +312,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
 # Baseline GWS.DRIVEDOCS.1.6v0.1
 #--
 NonCompliantOUs1_6[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -347,7 +347,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
 # Baseline GWS.DRIVEDOCS.1.7v0.1
 #--
 NonCompliantOUs1_7[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -382,7 +382,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
 # Baseline GWS.DRIVEDOCS.1.8v0.1
 #--
 NonCompliantOUs1_8[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -422,7 +422,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
 # Baseline GWS.DRIVEDOCS.2.1v0.1
 #--
 NonCompliantOUs2_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -458,7 +458,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
 # Baseline GWS.DRIVEDOCS.2.2v0.1
 #--
 NonCompliantOUs2_2[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -494,7 +494,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
 # Baseline GWS.DRIVEDOCS.2.3v0.1
 #--
 NonCompliantOUs2_3[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -530,7 +530,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
 # Baseline GWS.DRIVEDOCS.2.4v0.1
 #--
 NonCompliantOUs2_4[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -566,7 +566,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
 # Baseline GWS.DRIVEDOCS.2.5v0.1
 #--
 NonCompliantOUs2_5[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_download", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -623,7 +623,7 @@ NoSuchEvent3_1(TopLevelOU) := true if {
 default NoSuchEvent3_1(_) := false
 
 NonCompliantOUs3_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", OU)
     count(Events_A) > 0  
     LastEvent_A := GetLastEvent(Events_A)
@@ -633,7 +633,7 @@ NonCompliantOUs3_1[OU] {
     LastEvent_B := GetLastEvent(Events_B)
 
     Conditions := [LastEvent_A.NewValue != "false", LastEvent_B.NewValue != "REMOVE_LESS_SECURE_LINKS"]
-    count([Condition | Condition = Conditions[_]; Condition == true]) > 0
+    count([Condition | some Condition in Conditions; Condition == true]) > 0
 }
 
 tests[{ "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
@@ -665,7 +665,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
 # Baseline GWS.DRIVEDOCS.4.1v0.1
 #--
 NonCompliantOUs4_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("ENABLE_DRIVE_APPS", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -707,7 +707,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
 # Baseline GWS.DRIVEDOCS.5.1v0.1
 #--
 NonCompliantOUs5_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", OU)
     count(Events) > 0 
     LastEvent := GetLastEvent(Events)
@@ -762,7 +762,7 @@ NoSuchEvent6_1(TopLevelOU) := false if {
 }
 
 NonCompliantOUs6_1[OU] {
-    OU := OUsWithEvents[_]
+    some OU in OUsWithEvents
     Events_A := FilterEventsOU("DriveFsSettingsProto drive_fs_enabled", OU)
     count(Events_A) > 0
     LastEvent_A := GetLastEvent(Events_A)
@@ -774,7 +774,7 @@ NonCompliantOUs6_1[OU] {
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
     
     Conditions := [LastEvent_A.NewValue != "true", LastEvent_B.NewValue != "true"]
-    count([Condition | Condition = Conditions[_]; Condition == true]) > 0
+    count([Condition | some Condition in Conditions; Condition == true]) > 0
     
 }
 

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -461,9 +461,9 @@ if {
 }
 #--
 
-################
+###################
 # GWS.DRIVEDOCS.2 #
-################
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.2.1v0.1
@@ -671,14 +671,13 @@ if {
 #--
 
 
-################
-# GWS.DRIVEDOCS.3
-################
+###################
+# GWS.DRIVEDOCS.3 #
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.3.1v0.1
 #--
-
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
     Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU)
@@ -734,9 +733,9 @@ if {
 }
 #--
 
-################
-# GWS.DRIVEDOCS.4#
-################
+###################
+# GWS.DRIVEDOCS.4 #
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.4.1v0.1
@@ -781,9 +780,9 @@ if {
 #--
 
 
-################
+###################
 # GWS.DRIVEDOCS.5 #
-################
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.5.1v0.1
@@ -827,14 +826,13 @@ if {
 }
 #--
 
-################
-# GWS.DRIVEDOCS.6
-################
+###################
+# GWS.DRIVEDOCS.6 #
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.6.1v0.1
 #--
-
 default NoSuchEvent6_1(_) := true
 
 NoSuchEvent6_1(TopLevelOU) := false if {
@@ -890,12 +888,11 @@ if {
     not NoSuchEvent6_1(TopLevelOU)
     Status := count(NonCompliantOUs6_1) == 0
 }
-
 #--
 
-################
-# GWS.DRIVEDOCS.7
-################
+###################
+# GWS.DRIVEDOCS.7 #
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.7.1v0.1

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -1,11 +1,8 @@
 package drive
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.NoSuchEventDetails
 import data.utils.ReportDetailsOUs
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
-}
 
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -702,8 +702,10 @@ NonCompliantOUs3_1 contains OU if {
     count(Events_B) > 0
     LastEvent_B := GetLastEvent(Events_B)
 
-    Conditions := [LastEvent_A.NewValue != "false", LastEvent_B.NewValue != "REMOVE_LESS_SECURE_LINKS"]
-    count([Condition | some Condition in Conditions; Condition == true]) > 0
+    true in {
+        LastEvent_A.NewValue != "false",
+        LastEvent_B.NewValue != "REMOVE_LESS_SECURE_LINKS"
+    }
 }
 
 tests contains {
@@ -858,9 +860,10 @@ NonCompliantOUs6_1 contains OU if {
     LastEvent_B := GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
 
-    Conditions := [LastEvent_A.NewValue != "true", LastEvent_B.NewValue != "true"]
-    count([Condition | some Condition in Conditions; Condition == true]) > 0
-
+    true in {
+        LastEvent_A.NewValue != "true",
+        LastEvent_B.NewValue != "true"
+    }
 }
 
 tests contains {

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -1,6 +1,7 @@
 package drive
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.NoSuchEventDetails
 import data.utils.ReportDetailsOUs
@@ -94,14 +95,6 @@ if {
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
-GetLastEvent(Events) := Event if {
-    # Because CalendarSharingEvents returns a set instead
-    # of an array, we can't just index it and get the last
-    # value
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
-}
 
 ###################
 # GWS.DRIVEDOCS.1 #

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -141,7 +141,7 @@ GetLastEvent(Events) := Event if {
 # Baseline GWS.DRIVEDOCS.1.1v0.1
 #--
 # TODO: OU inheritence implementation pending after SCB updates, refer to #328
-NonCompliantOUs1_1[OU] {
+NonCompliantOUs1_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
@@ -149,23 +149,29 @@ NonCompliantOUs1_1[OU] {
     contains("SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
@@ -175,7 +181,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.2v0.1
 #--
-NonCompliantOUs1_2[OU] {
+NonCompliantOUs1_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
@@ -183,23 +189,29 @@ NonCompliantOUs1_2[OU] {
     contains("SHARING_NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
@@ -209,7 +221,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.3v0.1
 #--
-NonCompliantOUs1_3[OU] {
+NonCompliantOUs1_3 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
@@ -217,23 +229,29 @@ NonCompliantOUs1_3[OU] {
     contains("SHARING_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == true
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_3),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_3},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_3),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_3},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_3) == 0
@@ -243,7 +261,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.4v0.1
 #--
-NonCompliantOUs1_4[OU] {
+NonCompliantOUs1_4 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
     count(Events) > 0
@@ -251,23 +269,29 @@ NonCompliantOUs1_4[OU] {
     contains("NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_4),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_4},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_4),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_4},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_4) == 0
@@ -277,7 +301,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.5v0.1
 #--
-NonCompliantOUs1_5[OU] {
+NonCompliantOUs1_5 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("PUBLISHING_TO_WEB", OU)
     count(Events) > 0
@@ -285,23 +309,29 @@ NonCompliantOUs1_5[OU] {
     contains("ALLOWED", LastEvent.NewValue) == true
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_5),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_5},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_5),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_5},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_5) == 0
@@ -311,7 +341,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.6v0.1
 #--
-NonCompliantOUs1_6[OU] {
+NonCompliantOUs1_6 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS", OU)
     count(Events) > 0
@@ -319,24 +349,29 @@ NonCompliantOUs1_6[OU] {
     contains("NAMED_PARTIES_ONLY DOMAIN_OR_NAMED_PARTIES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent":true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_6),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_6},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_6),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_6},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_6) == 0
@@ -346,7 +381,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.7v0.1
 #--
-NonCompliantOUs1_7[OU] {
+NonCompliantOUs1_7 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
     count(Events) > 0
@@ -354,24 +389,29 @@ NonCompliantOUs1_7[OU] {
     contains("CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_7),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs1_7},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_7),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs1_7},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_7) == 0
@@ -381,7 +421,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
 #
 # Baseline GWS.DRIVEDOCS.1.8v0.1
 #--
-NonCompliantOUs1_8[OU] {
+NonCompliantOUs1_8 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
     count(Events) > 0
@@ -390,24 +430,29 @@ NonCompliantOUs1_8[OU] {
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent":true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_8),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_8},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_8),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_8},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_8) == 0
@@ -421,7 +466,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
 #
 # Baseline GWS.DRIVEDOCS.2.1v0.1
 #--
-NonCompliantOUs2_1[OU] {
+NonCompliantOUs2_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", OU)
     count(Events) > 0
@@ -430,24 +475,29 @@ NonCompliantOUs2_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -457,7 +507,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
 #
 # Baseline GWS.DRIVEDOCS.2.2v0.1
 #--
-NonCompliantOUs2_2[OU] {
+NonCompliantOUs2_2 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", OU)
     count(Events) > 0
@@ -466,24 +516,29 @@ NonCompliantOUs2_2[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_2),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_2},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_2),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_2},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_2) == 0
@@ -493,7 +548,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
 #
 # Baseline GWS.DRIVEDOCS.2.3v0.1
 #--
-NonCompliantOUs2_3[OU] {
+NonCompliantOUs2_3 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
     count(Events) > 0
@@ -502,24 +557,29 @@ NonCompliantOUs2_3[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_3),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_3},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_3),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_3},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_3) == 0
@@ -529,7 +589,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
 #
 # Baseline GWS.DRIVEDOCS.2.4v0.1
 #--
-NonCompliantOUs2_4[OU] {
+NonCompliantOUs2_4 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", OU)
     count(Events) > 0
@@ -538,24 +598,29 @@ NonCompliantOUs2_4[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_4),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_4},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_4),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_4},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_4) == 0
@@ -565,7 +630,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
 #
 # Baseline GWS.DRIVEDOCS.2.5v0.1
 #--
-NonCompliantOUs2_5[OU] {
+NonCompliantOUs2_5 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_download", OU)
     count(Events) > 0
@@ -574,30 +639,34 @@ NonCompliantOUs2_5[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_download", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_5),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_5},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_5),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_5},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_download", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_5) == 0
 }
 #--
-
 
 
 ################
@@ -622,7 +691,7 @@ NoSuchEvent3_1(TopLevelOU) := true if {
 
 default NoSuchEvent3_1(_) := false
 
-NonCompliantOUs3_1[OU] {
+NonCompliantOUs3_1 contains OU if {
     some OU in OUsWithEvents
     Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", OU)
     count(Events_A) > 0
@@ -636,22 +705,28 @@ NonCompliantOUs3_1[OU] {
     count([Condition | some Condition in Conditions; Condition == true]) > 0
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     NoSuchEvent3_1(TopLevelOU)
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
-        "ActualValue" : {"NonComplaintOUs": NonCompliantOUs3_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ActualValue" : {"NonComplaintOUs": NonCompliantOUs3_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     not NoSuchEvent3_1(TopLevelOU)
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -664,7 +739,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
 #
 # Baseline GWS.DRIVEDOCS.4.1v0.1
 #--
-NonCompliantOUs4_1[OU] {
+NonCompliantOUs4_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ENABLE_DRIVE_APPS", OU)
     count(Events) > 0
@@ -673,25 +748,30 @@ NonCompliantOUs4_1[OU] {
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent":true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("ENABLE_DRIVE_APPS", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs4_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs4_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("ENABLE_DRIVE_APPS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
@@ -706,7 +786,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
 #
 # Baseline GWS.DRIVEDOCS.5.1v0.1
 #--
-NonCompliantOUs5_1[OU] {
+NonCompliantOUs5_1 contains OU if {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", OU)
     count(Events) > 0
@@ -715,25 +795,30 @@ NonCompliantOUs5_1[OU] {
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)
-    count(Events) == 0 # If no Events were logged, then the default
-    # value is still active
+    count(Events) == 0
 
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
-        "Criticality": "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
-        "ActualValue": {"NonComplaintOUs": NonCompliantOUs5_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ActualValue": {"NonComplaintOUs": NonCompliantOUs5_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
@@ -761,7 +846,7 @@ NoSuchEvent6_1(TopLevelOU) := false if {
     count(Events) != 0
 }
 
-NonCompliantOUs6_1[OU] {
+NonCompliantOUs6_1 contains OU if {
     some OU in OUsWithEvents
     Events_A := FilterEventsOU("DriveFsSettingsProto drive_fs_enabled", OU)
     count(Events_A) > 0
@@ -778,22 +863,28 @@ NonCompliantOUs6_1[OU] {
 
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event for the top-level OU in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
     NoSuchEvent6_1(TopLevelOU)
 }
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_1),
-        "ActualValue" : {"NonComplaintOUs": NonCompliantOUs6_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_1),
+    "ActualValue" : {"NonComplaintOUs": NonCompliantOUs6_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     not NoSuchEvent6_1(TopLevelOU)
     Status := count(NonCompliantOUs6_1) == 0
 }
@@ -810,13 +901,12 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
 # Baseline GWS.DRIVEDOCS.7.1v0.1
 #--
 
-tests[{ "PolicyId": "GWS.DRIVEDOCS.7.1v0.1",
-        "Criticality": "Should/Not-Implemented",
-        "ReportDetails": "Currently not able to be tested automatically; please manually check.",
-        "ActualValue": "",
-        "RequirementMet": false,
-        "NoSuchEvent": true}] {
-    true
-
+tests contains {
+    "PolicyId": "GWS.DRIVEDOCS.7.1v0.1",
+    "Criticality": "Should/Not-Implemented",
+    "ReportDetails": "Currently not able to be tested automatically; please manually check.",
+    "ActualValue": "",
+    "RequirementMet": false,
+    "NoSuchEvent": true
 }
 #--

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -1,11 +1,7 @@
 package drive
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.FilterEvents
-import data.utils.OUsWithEvents
-import data.utils.NoSuchEventDetails
-import data.utils.ReportDetailsOUs
 
 ###################
 # GWS.DRIVEDOCS.1 #
@@ -16,10 +12,10 @@ import data.utils.ReportDetailsOUs
 #--
 # TODO: OU inheritence implementation pending after SCB updates, refer to #328
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     SettingValue := "SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT"
     contains(SettingValue, LastEvent.NewValue) == false
 }
@@ -27,27 +23,27 @@ NonCompliantOUs1_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -57,37 +53,37 @@ if {
 # Baseline GWS.DRIVEDOCS.1.2v0.1
 #--
 NonCompliantOUs1_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("SHARING_NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -97,37 +93,37 @@ if {
 # Baseline GWS.DRIVEDOCS.1.3v0.1
 #--
 NonCompliantOUs1_3 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("SHARING_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == true
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_OUTSIDE_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_3) == 0
 }
@@ -137,37 +133,37 @@ if {
 # Baseline GWS.DRIVEDOCS.1.4v0.1
 #--
 NonCompliantOUs1_4 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_4) == 0
 }
@@ -177,37 +173,37 @@ if {
 # Baseline GWS.DRIVEDOCS.1.5v0.1
 #--
 NonCompliantOUs1_5 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("PUBLISHING_TO_WEB", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("PUBLISHING_TO_WEB", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("ALLOWED", LastEvent.NewValue) == true
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("PUBLISHING_TO_WEB", TopLevelOU)
+    Events := utils.FilterEvents("PUBLISHING_TO_WEB", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_5),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("PUBLISHING_TO_WEB", TopLevelOU)
+    Events := utils.FilterEvents("PUBLISHING_TO_WEB", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_5) == 0
 }
@@ -217,37 +213,37 @@ if {
 # Baseline GWS.DRIVEDOCS.1.6v0.1
 #--
 NonCompliantOUs1_6 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("NAMED_PARTIES_ONLY DOMAIN_OR_NAMED_PARTIES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)
+    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS",utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_6),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_6),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_6},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_ACCESS_CHECKER_OPTIONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_6) == 0
 }
@@ -257,10 +253,10 @@ if {
 # Baseline GWS.DRIVEDOCS.1.7v0.1
 #--
 NonCompliantOUs1_7 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     SettingValue := "CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT"
     contains(SettingValue, LastEvent.NewValue) == false
 }
@@ -268,27 +264,27 @@ NonCompliantOUs1_7 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_7),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_7),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs1_7},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)
+    Events := utils.FilterEvents("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_7) == 0
 }
@@ -298,10 +294,10 @@ if {
 # Baseline GWS.DRIVEDOCS.1.8v0.1
 #--
 NonCompliantOUs1_8 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "PRIVATE"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -309,27 +305,27 @@ NonCompliantOUs1_8 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)
+    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_8),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_8),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_8},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", TopLevelOU)
+    Events := utils.FilterEvents("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_8) == 0
 }
@@ -343,10 +339,10 @@ if {
 # Baseline GWS.DRIVEDOCS.2.1v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Shared Drive Creation CanCreateSharedDrives", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -354,27 +350,27 @@ NonCompliantOUs2_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation CanCreateSharedDrives", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -384,10 +380,10 @@ if {
 # Baseline GWS.DRIVEDOCS.2.2v0.1
 #--
 NonCompliantOUs2_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Shared Drive Creation new_team_drive_admin_only", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -395,27 +391,27 @@ NonCompliantOUs2_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_2),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_admin_only", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_2) == 0
 }
@@ -425,10 +421,10 @@ if {
 # Baseline GWS.DRIVEDOCS.2.3v0.1
 #--
 NonCompliantOUs2_3 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -436,27 +432,27 @@ NonCompliantOUs2_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_3),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_cross_domain_access", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_3) == 0
 }
@@ -466,10 +462,10 @@ if {
 # Baseline GWS.DRIVEDOCS.2.4v0.1
 #--
 NonCompliantOUs2_4 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -477,27 +473,27 @@ NonCompliantOUs2_4 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_4),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_direct_access", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_4) == 0
 }
@@ -507,10 +503,10 @@ if {
 # Baseline GWS.DRIVEDOCS.2.5v0.1
 #--
 NonCompliantOUs2_5 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_download", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     contains("false", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -518,27 +514,27 @@ NonCompliantOUs2_5 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_download", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_5),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs2_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Shared Drive Creation new_team_drive_restricts_download", TopLevelOU)
+    Events := utils.FilterEvents("Shared Drive Creation new_team_drive_restricts_download", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_5) == 0
 }
@@ -554,27 +550,27 @@ if {
 #--
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events_A := FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU)
+    Events_A := utils.FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU)
     count(Events_A) == 0
 }
 
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events := FilterEvents("Link Security Update Settings less_secure_link_option", TopLevelOU)
+    Events := utils.FilterEvents("Link Security Update Settings less_secure_link_option", TopLevelOU)
     count(Events) == 0
 }
 
 default NoSuchEvent3_1(_) := false
 
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events_A := FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", OU)
+    some OU in utils.OUsWithEvents
+    Events_A := utils.FilterEvents("Link Security Update Settings allow_less_secure_link_user_restore", OU)
     count(Events_A) > 0
-    LastEvent_A := GetLastEvent(Events_A)
+    LastEvent_A := utils.GetLastEvent(Events_A)
 
-    Events_B := FilterEvents("Link Security Update Settings less_secure_link_option", OU)
+    Events_B := utils.FilterEvents("Link Security Update Settings less_secure_link_option", OU)
     count(Events_B) > 0
-    LastEvent_B := GetLastEvent(Events_B)
+    LastEvent_B := utils.GetLastEvent(Events_B)
 
     true in {
         LastEvent_A.NewValue != "false",
@@ -585,26 +581,26 @@ NonCompliantOUs3_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    NoSuchEvent3_1(TopLevelOU)
+    NoSuchEvent3_1(utils.TopLevelOU)
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue" : {"NonComplaintOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    not NoSuchEvent3_1(TopLevelOU)
+    not NoSuchEvent3_1(utils.TopLevelOU)
     Status := count(NonCompliantOUs3_1) == 0
 }
 #--
@@ -617,10 +613,10 @@ if {
 # Baseline GWS.DRIVEDOCS.4.1v0.1
 #--
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_DRIVE_APPS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -628,14 +624,14 @@ NonCompliantOUs4_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_DRIVE_APPS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", utils.TopLevelOU)
     count(Events) == 0
 
 }
@@ -643,13 +639,13 @@ if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_DRIVE_APPS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_DRIVE_APPS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -664,10 +660,10 @@ if {
 # Baseline GWS.DRIVEDOCS.5.1v0.1
 #--
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_DOCS_ADD_ONS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -675,14 +671,14 @@ NonCompliantOUs5_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_DOCS_ADD_ONS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
     count(Events) == 0
 
 }
@@ -690,13 +686,13 @@ if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonComplaintOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_DOCS_ADD_ONS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_DOCS_ADD_ONS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -712,26 +708,26 @@ if {
 default NoSuchEvent6_1(_) := true
 
 NoSuchEvent6_1(TopLevelOU) := false if {
-    Events := FilterEvents("DriveFsSettingsProto drive_fs_enabled", TopLevelOU)
+    Events := utils.FilterEvents("DriveFsSettingsProto drive_fs_enabled", TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent6_1(TopLevelOU) := false if {
     # No such event...
-    Events := FilterEvents("DriveFsSettingsProto company_owned_only_enabled", TopLevelOU)
+    Events := utils.FilterEvents("DriveFsSettingsProto company_owned_only_enabled", TopLevelOU)
     count(Events) != 0
 }
 
 NonCompliantOUs6_1 contains OU if {
-    some OU in OUsWithEvents
-    Events_A := FilterEvents("DriveFsSettingsProto drive_fs_enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events_A := utils.FilterEvents("DriveFsSettingsProto drive_fs_enabled", OU)
     count(Events_A) > 0
-    LastEvent_A := GetLastEvent(Events_A)
+    LastEvent_A := utils.GetLastEvent(Events_A)
     LastEvent_A.NewValue != "DELETE_APPLICATION_SETTING"
 
-    Events_B := FilterEvents("DriveFsSettingsProto company_owned_only_enabled", OU)
+    Events_B := utils.FilterEvents("DriveFsSettingsProto company_owned_only_enabled", OU)
     count(Events_B) > 0
-    LastEvent_B := GetLastEvent(Events_B)
+    LastEvent_B := utils.GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
 
     true in {
@@ -743,26 +739,26 @@ NonCompliantOUs6_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    NoSuchEvent6_1(TopLevelOU)
+    NoSuchEvent6_1(utils.TopLevelOU)
 }
 
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs6_1),
     "ActualValue" : {"NonComplaintOUs": NonCompliantOUs6_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    not NoSuchEvent6_1(TopLevelOU)
+    not NoSuchEvent6_1(utils.TopLevelOU)
     Status := count(NonCompliantOUs6_1) == 0
 }
 #--

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -144,7 +144,7 @@ GetLastEvent(Events) := Event if {
 NonCompliantOUs1_1[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
@@ -156,7 +156,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)    
+    Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)   
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -212,7 +212,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.2v0.1",
 NonCompliantOUs1_3[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("SHARING_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == true
 }
@@ -246,7 +246,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.3v0.1",
 NonCompliantOUs1_4[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("NOT_ALLOWED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
@@ -258,7 +258,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)    
+    Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)   
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -280,7 +280,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
 NonCompliantOUs1_5[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("PUBLISHING_TO_WEB", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("ALLOWED", LastEvent.NewValue) == true
 }
@@ -292,7 +292,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)    
+    Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)   
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -314,7 +314,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
 NonCompliantOUs1_6[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("NAMED_PARTIES_ONLY DOMAIN_OR_NAMED_PARTIES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
@@ -326,8 +326,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent":true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -349,7 +349,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
 NonCompliantOUs1_7[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
 }
@@ -361,8 +361,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -384,7 +384,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
 NonCompliantOUs1_8[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "PRIVATE"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
@@ -397,8 +397,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent":true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -437,8 +437,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -460,7 +460,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
 NonCompliantOUs2_2[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
@@ -473,8 +473,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -496,7 +496,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
 NonCompliantOUs2_3[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     contains("true", LastEvent.NewValue) == false
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
@@ -509,8 +509,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -545,8 +545,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
 
@@ -601,7 +601,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
 
 
 ################
-# GWS.DRIVEDOCS.3 
+# GWS.DRIVEDOCS.3
 ################
 
 #
@@ -610,13 +610,13 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.5v0.1",
 
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU) 
+    Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", TopLevelOU)
     count(Events_A) == 0
 }
 
 NoSuchEvent3_1(TopLevelOU) := true if {
     # No such event...
-    Events := FilterEventsOU("Link Security Update Settings less_secure_link_option", TopLevelOU) 
+    Events := FilterEventsOU("Link Security Update Settings less_secure_link_option", TopLevelOU)
     count(Events) == 0
 }
 
@@ -625,11 +625,11 @@ default NoSuchEvent3_1(_) := false
 NonCompliantOUs3_1[OU] {
     some OU in OUsWithEvents
     Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", OU)
-    count(Events_A) > 0  
+    count(Events_A) > 0 
     LastEvent_A := GetLastEvent(Events_A)
-    
+   
     Events_B := FilterEventsOU("Link Security Update Settings less_secure_link_option", OU)
-    count(Events_B) > 0  
+    count(Events_B) > 0 
     LastEvent_B := GetLastEvent(Events_B)
 
     Conditions := [LastEvent_A.NewValue != "false", LastEvent_B.NewValue != "REMOVE_LESS_SECURE_LINKS"]
@@ -709,7 +709,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.4.1v0.1",
 NonCompliantOUs5_1[OU] {
     some OU in OUsWithEvents
     Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", OU)
-    count(Events) > 0 
+    count(Events) > 0
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
@@ -722,8 +722,8 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)    
-    count(Events) == 0 # If no Events were logged, then the default 
+    Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)   
+    count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 
 }
@@ -741,7 +741,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
 #--
 
 ################
-# GWS.DRIVEDOCS.6 
+# GWS.DRIVEDOCS.6
 ################
 
 #
@@ -772,10 +772,10 @@ NonCompliantOUs6_1[OU] {
     count(Events_B) > 0
     LastEvent_B := GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
-    
+   
     Conditions := [LastEvent_A.NewValue != "true", LastEvent_B.NewValue != "true"]
     count([Condition | some Condition in Conditions; Condition == true]) > 0
-    
+   
 }
 
 tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
@@ -801,10 +801,10 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",
 #--
 
 ################
-# GWS.DRIVEDOCS.7 
+# GWS.DRIVEDOCS.7
 ################
 
-# not implementable: Need a way to see when a rule is created. The fact that a rule is created gets logged but the rule's contents are not. 
+# not implementable: Need a way to see when a rule is created. The fact that a rule is created gets logged but the rule's contents are not.
 
 #
 # Baseline GWS.DRIVEDOCS.7.1v0.1

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -133,9 +133,9 @@ GetLastEvent(Events) := Event if {
     Event.Timestamp == MaxTs
 }
 
-################
+###################
 # GWS.DRIVEDOCS.1 #
-################
+###################
 
 #
 # Baseline GWS.DRIVEDOCS.1.1v0.1
@@ -156,7 +156,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)   
+    Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -258,7 +258,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.4v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)   
+    Events := FilterEventsOU("SHARING_INVITES_TO_NON_GOOGLE_ACCOUNTS", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -292,7 +292,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.5v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)   
+    Events := FilterEventsOU("PUBLISHING_TO_WEB", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
 }
 
@@ -326,7 +326,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.6v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent":true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)   
+    Events := FilterEventsOU("SHARING_ACCESS_CHECKER_OPTIONS",TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -361,7 +361,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.7v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)   
+    Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -397,7 +397,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.1.8v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent":true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)   
+    Events := FilterEventsOU("DEFAULT_LINK_SHARING_FOR_NEW_DOCS",TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -437,7 +437,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)   
+    Events := FilterEventsOU("Shared Drive Creation CanCreateSharedDrives", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -473,7 +473,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.2v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)   
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_admin_only", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -509,7 +509,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.3v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)   
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_cross_domain_access", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -545,7 +545,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.2.4v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)   
+    Events := FilterEventsOU("Shared Drive Creation new_team_drive_restricts_direct_access", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 }
@@ -625,11 +625,11 @@ default NoSuchEvent3_1(_) := false
 NonCompliantOUs3_1[OU] {
     some OU in OUsWithEvents
     Events_A := FilterEventsOU("Link Security Update Settings allow_less_secure_link_user_restore", OU)
-    count(Events_A) > 0 
+    count(Events_A) > 0
     LastEvent_A := GetLastEvent(Events_A)
-   
+
     Events_B := FilterEventsOU("Link Security Update Settings less_secure_link_option", OU)
-    count(Events_B) > 0 
+    count(Events_B) > 0
     LastEvent_B := GetLastEvent(Events_B)
 
     Conditions := [LastEvent_A.NewValue != "false", LastEvent_B.NewValue != "REMOVE_LESS_SECURE_LINKS"]
@@ -722,7 +722,7 @@ tests[{ "PolicyId": "GWS.DRIVEDOCS.5.1v0.1",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}] {
     DefaultSafe := false
-    Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)   
+    Events := FilterEventsOU("ENABLE_DOCS_ADD_ONS", TopLevelOU)
     count(Events) == 0 # If no Events were logged, then the default
     # value is still active
 
@@ -772,10 +772,10 @@ NonCompliantOUs6_1[OU] {
     count(Events_B) > 0
     LastEvent_B := GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
-   
+
     Conditions := [LastEvent_A.NewValue != "true", LastEvent_B.NewValue != "true"]
     count([Condition | some Condition in Conditions; Condition == true]) > 0
-   
+
 }
 
 tests[{ "PolicyId": "GWS.DRIVEDOCS.6.1v0.1",

--- a/rego/Drive.rego
+++ b/rego/Drive.rego
@@ -146,7 +146,8 @@ NonCompliantOUs1_1 contains OU if {
     Events := FilterEventsOU("SHARING_OUTSIDE_DOMAIN", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
-    contains("SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT", LastEvent.NewValue) == false
+    SettingValue := "SHARING_NOT_ALLOWED SHARING_NOT_ALLOWED_BUT_MAY_RECEIVE_FILES INHERIT_FROM_PARENT"
+    contains(SettingValue, LastEvent.NewValue) == false
 }
 
 tests contains {
@@ -386,7 +387,8 @@ NonCompliantOUs1_7 contains OU if {
     Events := FilterEventsOU("SHARING_TEAM_DRIVE_CROSS_DOMAIN_OPTIONS", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
-    contains("CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT", LastEvent.NewValue) == false
+    SettingValue := "CROSS_DOMAIN_FROM_INTERNAL_ONLY CROSS_DOMAIN_MOVES_BLOCKED INHERIT_FROM_PARENT"
+    contains(SettingValue, LastEvent.NewValue) == false
 }
 
 tests contains {
@@ -895,12 +897,12 @@ if {
 # GWS.DRIVEDOCS.7
 ################
 
-# not implementable: Need a way to see when a rule is created. The fact that a rule is created gets logged but the rule's contents are not.
-
 #
 # Baseline GWS.DRIVEDOCS.7.1v0.1
 #--
-
+# not implementable: Need a way to see when a rule is created.
+# The fact that a rule is created gets logged but the rule's
+# contents are not.
 tests contains {
     "PolicyId": "GWS.DRIVEDOCS.7.1v0.1",
     "Criticality": "Should/Not-Implemented",

--- a/rego/Gmail.rego
+++ b/rego/Gmail.rego
@@ -1,12 +1,7 @@
 package gmail
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.FilterEvents
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.FilterEventsNoOU
-import data.utils.NoSuchEventDetails
 
 Format(Array) := format_int(count(Array), 10)
 
@@ -37,40 +32,40 @@ AllDomains contains Domain.domain if {
 # Baseline GWS.GMAIL.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := true
-    Events := FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -237,14 +232,14 @@ if {
 # Baseline GWS.GMAIL.5.1v0.1
 #--
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -252,28 +247,28 @@ NonCompliantOUs5_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 } if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.5.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -282,14 +277,14 @@ if {
 # Baseline GWS.GMAIL.5.2v0.1
 #--
 NonCompliantOUs5_2 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -297,7 +292,7 @@ NonCompliantOUs5_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.5.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -305,21 +300,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.5.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_2) == 0
 }
@@ -347,14 +342,14 @@ EncryptedAttachmentSettingDetailsStr(LastEvent) := Description if {
 # Baseline GWS.GMAIL.5.3v0.1
 #--
 NonCompliantOUs5_3 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -362,7 +357,7 @@ NonCompliantOUs5_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.5.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -370,21 +365,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.5.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_3) == 0
 }
@@ -394,13 +389,13 @@ if {
 # Baseline GWS.GMAIL.5.4v0.1
 #--
 NonCompliantOUs5_4 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Attachment safety Enable: automatically enables all future added settings", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Attachment safety Enable: automatically enables all future added settings", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -408,27 +403,29 @@ NonCompliantOUs5_4 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.5.4v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Attachment safety Enable: automatically enables all future added settings", TopLevelOU)
+    SettingName := "Attachment safety Enable: automatically enables all future added settings"
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.5.4v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Attachment safety Enable: automatically enables all future added settings", TopLevelOU)
+    SettingName := "Attachment safety Enable: automatically enables all future added settings"
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_4) == 0
 }
@@ -441,35 +438,35 @@ default NoSuchEvent5_5(_) := true
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := FilterEvents("Attachment safety Encrypted attachment protection setting action", TopLevelOU)
+    Events := utils.FilterEvents("Attachment safety Encrypted attachment protection setting action", TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := FilterEvents("Attachment safety Attachment with scripts protection action", TopLevelOU)
+    Events := utils.FilterEvents("Attachment safety Attachment with scripts protection action", TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := FilterEvents("Attachment safety Anomalous attachment protection setting action", TopLevelOU)
+    Events := utils.FilterEvents("Attachment safety Anomalous attachment protection setting action", TopLevelOU)
     count(Events) != 0
 }
 
 NonCompliantOUs5_5 contains OU if {
-    some OU in OUsWithEvents
-    Events_A := FilterEvents("Attachment safety Encrypted attachment protection setting action", OU)
+    some OU in utils.OUsWithEvents
+    Events_A := utils.FilterEvents("Attachment safety Encrypted attachment protection setting action", OU)
     count(Events_A) > 0
-    LastEvent_A := GetLastEvent(Events_A)
+    LastEvent_A := utils.GetLastEvent(Events_A)
 
-    Events_B := FilterEvents("Attachment safety Attachment with scripts protection action", OU)
+    Events_B := utils.FilterEvents("Attachment safety Attachment with scripts protection action", OU)
     count(Events_B) > 0
-    LastEvent_B := GetLastEvent(Events_B)
+    LastEvent_B := utils.GetLastEvent(Events_B)
 
-    Events_C := FilterEvents("Attachment safety Anomalous attachment protection setting action", OU)
+    Events_C := utils.FilterEvents("Attachment safety Anomalous attachment protection setting action", OU)
     count(Events_C) > 0
-    LastEvent_C := GetLastEvent(Events_C)
+    LastEvent_C := utils.GetLastEvent(Events_C)
 
     true in [
         LastEvent_A.NewValue == "Show warning",
@@ -481,26 +478,26 @@ NonCompliantOUs5_5 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.5.5v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    NoSuchEvent5_5(TopLevelOU)
+    NoSuchEvent5_5(utils.TopLevelOU)
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.5.5v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_5),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    not NoSuchEvent5_5(TopLevelOU)
+    not NoSuchEvent5_5(utils.TopLevelOU)
     Status := count(NonCompliantOUs5_5) == 0
 }
 #--
@@ -526,14 +523,14 @@ tests contains {
 # Baseline GWS.GMAIL.6.1v0.1
 #--
 NonCompliantOUs6_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -541,7 +538,7 @@ NonCompliantOUs6_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.6.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -549,21 +546,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.6.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs6_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
 }
@@ -573,10 +570,10 @@ if {
 # Baseline GWS.GMAIL.6.2v0.1
 #--
 NonCompliantOUs6_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("Links and external images safety Enable: scan linked images", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -584,27 +581,27 @@ NonCompliantOUs6_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.6.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("Links and external images safety Enable: scan linked images", TopLevelOU)
+    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.6.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs6_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("Links and external images safety Enable: scan linked images", TopLevelOU)
+    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_2) == 0
 }
@@ -614,14 +611,14 @@ if {
 # Baseline GWS.GMAIL.6.3v0.1
 #--
 NonCompliantOUs6_3 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := concat("", [
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -629,7 +626,7 @@ NonCompliantOUs6_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.6.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -640,14 +637,14 @@ if {
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.6.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs6_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -657,7 +654,7 @@ if {
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_3) == 0
 }
@@ -667,14 +664,14 @@ if {
 # Baseline GWS.GMAIL.6.4v0.1
 #--
 NonCompliantOUs6_4 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -682,7 +679,7 @@ NonCompliantOUs6_4 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.6.4v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -690,21 +687,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.6.4v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs6_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs6_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_4) == 0
 }
@@ -731,14 +728,14 @@ tests contains {
 # Baseline GWS.GMAIL.7.1v0.1
 #--
 NonCompliantOUs7_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := concat("", [
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -746,7 +743,7 @@ NonCompliantOUs7_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -757,14 +754,14 @@ if {
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -774,7 +771,7 @@ if {
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_1) == 0
 }
@@ -784,14 +781,14 @@ if {
 # Baseline GWS.GMAIL.7.2v0.1
 #--
 NonCompliantOUs7_2 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -799,7 +796,7 @@ NonCompliantOUs7_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -807,21 +804,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_2) == 0
 }
@@ -831,14 +828,14 @@ if {
 # Baseline GWS.GMAIL.7.3v0.1
 #--
 NonCompliantOUs7_3 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -846,7 +843,7 @@ NonCompliantOUs7_3 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -854,21 +851,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.3v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_3),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_3),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_3},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_3) == 0
 }
@@ -878,14 +875,14 @@ if {
 # Baseline GWS.GMAIL.7.4v0.1
 #--
 NonCompliantOUs7_4 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -893,7 +890,7 @@ NonCompliantOUs7_4 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -901,21 +898,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.4v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_4),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_4),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_4},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_4) == 0
 }
@@ -926,17 +923,17 @@ if {
 #--
 
 NonCompliantOUs7_5 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := concat("", [
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -944,7 +941,7 @@ NonCompliantOUs7_5 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -955,14 +952,14 @@ if {
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.5v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_5),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_5),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_5},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -972,7 +969,7 @@ if {
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_5) == 0
 }
@@ -990,14 +987,14 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect against domain spoofing based on similar ",
         "domain names action"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent7_6(TopLevelOU) := false if {
     # No such event...
     SettingName := "Spoofing and authentication safety Protect against spoofing of employee names action"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, TopLevelOU)
     count(Events) != 0
 }
 
@@ -1007,14 +1004,14 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect against domain spoofing based on similar ",
         "domain names action"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent7_6(TopLevelOU) := false if {
     # No such event...
     SettingName := "Spoofing and authentication safety Protect against any unauthenticated emails action"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, TopLevelOU)
     count(Events) != 0
 }
 
@@ -1024,43 +1021,43 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect your Groups from inbound emails spoofing ",
         "your domain action"
     ])
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NonCompliantOUs7_6 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
 
     SettingA := concat("", [
         "Spoofing and authentication safety Protect against domain spoofing based on ",
         "similar domain names action"
     ])
-    EventsA := FilterEvents(SettingA, OU)
+    EventsA := utils.FilterEvents(SettingA, OU)
     count(EventsA) > 0
-    LastEventA := GetLastEvent(EventsA)
+    LastEventA := utils.GetLastEvent(EventsA)
 
     SettingB := "Spoofing and authentication safety Protect against spoofing of employee names action"
-    EventsB := FilterEvents(SettingB, OU)
+    EventsB := utils.FilterEvents(SettingB, OU)
     count(EventsB) > 0
-    LastEventB := GetLastEvent(EventsB)
+    LastEventB := utils.GetLastEvent(EventsB)
 
     SettingC := "Spoofing and authentication safety Protect against inbound emails spoofing your domain action"
-    EventsC := FilterEvents(SettingC, OU)
+    EventsC := utils.FilterEvents(SettingC, OU)
     count(EventsC) > 0
-    LastEventC := GetLastEvent(EventsC)
+    LastEventC := utils.GetLastEvent(EventsC)
 
     SettingD := "Spoofing and authentication safety Protect against any unauthenticated emails action"
-    EventsD := FilterEvents(SettingD, OU)
+    EventsD := utils.FilterEvents(SettingD, OU)
     count(EventsD) > 0
-    LastEventD := GetLastEvent(EventsD)
+    LastEventD := utils.GetLastEvent(EventsD)
 
     SettingE := concat("", [
         "Spoofing and authentication safety Protect your Groups from inbound emails spoofing ",
         "your domain action"
     ])
-    EventsE := FilterEvents(SettingE, OU)
+    EventsE := utils.FilterEvents(SettingE, OU)
     count(EventsE) > 0
-    LastEventE := GetLastEvent(EventsE)
+    LastEventE := utils.GetLastEvent(EventsE)
 
     # OU is non-compliant if any of the following are true
     true in [
@@ -1076,26 +1073,26 @@ NonCompliantOUs7_6 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.6v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    NoSuchEvent7_6(TopLevelOU)
+    NoSuchEvent7_6(utils.TopLevelOU)
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.6v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_6),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_6),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_6},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    not NoSuchEvent7_6(TopLevelOU)
+    not NoSuchEvent7_6(utils.TopLevelOU)
     Status := count(NonCompliantOUs7_6) == 0
 }
 #--
@@ -1105,14 +1102,14 @@ if {
 #--
 
 NonCompliantOUs7_7 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -1120,7 +1117,7 @@ NonCompliantOUs7_7 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.7.7v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": false,
     "NoSuchEvent": true
@@ -1128,21 +1125,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := FilterEventsNoOU(SettingName)
+    Events := utils.FilterEventsNoOU(SettingName)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.7.7v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs7_7),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_7),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_7},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := FilterEventsNoOU(SettingName)
+    Events := utils.FilterEventsNoOU(SettingName)
     count(Events) > 0
     Status := count(NonCompliantOUs7_7) == 0
 }
@@ -1171,40 +1168,40 @@ tests contains {
 # Baseline GWS.GMAIL.8.1v0.1
 #--
 NonCompliantOUs8_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_EMAIL_USER_IMPORT", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.8.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_EMAIL_USER_IMPORT", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.8.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs8_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs8_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs8_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_EMAIL_USER_IMPORT", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs8_1) == 0
 }
@@ -1218,10 +1215,10 @@ if {
 # Baseline GWS.GMAIL.9.1v0.1
 #--
 NonCompliantOUs9_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("IMAP_ACCESS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("IMAP_ACCESS", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DISABLED"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -1229,27 +1226,27 @@ NonCompliantOUs9_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.9.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("IMAP_ACCESS", TopLevelOU)
+    Events := utils.FilterEvents("IMAP_ACCESS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.9.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs9_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs9_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs9_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("IMAP_ACCESS", TopLevelOU)
+    Events := utils.FilterEvents("IMAP_ACCESS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_1) == 0
 }
@@ -1259,13 +1256,13 @@ if {
 # Baseline GWS.GMAIL.9.2v0.1
 #--
 NonCompliantOUs9_2 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_POP_ACCESS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_POP_ACCESS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -1273,27 +1270,27 @@ NonCompliantOUs9_2 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.9.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_POP_ACCESS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_POP_ACCESS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.9.2v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs9_2),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs9_2),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs9_2},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_POP_ACCESS", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_POP_ACCESS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_2) == 0
 }
@@ -1308,10 +1305,10 @@ if {
 # Baseline GWS.GMAIL.10.1v0.1
 #--
 NonCompliantOUs10_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_OUTLOOK_SYNC", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -1319,27 +1316,27 @@ NonCompliantOUs10_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.10.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_OUTLOOK_SYNC", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.10.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs10_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs10_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs10_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_OUTLOOK_SYNC", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs10_1) == 0
 }
@@ -1355,13 +1352,13 @@ if {
 #--
 
 NonCompliantOUs11_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -1369,27 +1366,27 @@ NonCompliantOUs11_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.11.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.11.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs11_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs11_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs11_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", TopLevelOU)
+    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs11_1) == 0
 }
@@ -1404,40 +1401,40 @@ if {
 # Baseline GWS.GMAIL.12.1v0.1
 #--
 NonCompliantOUs12_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "1"
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.12.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", TopLevelOU)
+    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.12.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs12_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs12_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs12_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", TopLevelOU)
+    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs12_1) == 0
 }
@@ -1452,40 +1449,40 @@ if {
 # Baseline GWS.GMAIL.13.1v0.1
 #--
 NonCompliantOUs13_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("OUTBOUND_RELAY_ENABLED", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.13.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("OUTBOUND_RELAY_ENABLED", TopLevelOU)
+    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.13.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs13_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs13_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs13_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("OUTBOUND_RELAY_ENABLED", TopLevelOU)
+    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs13_1) == 0
 }
@@ -1500,13 +1497,13 @@ if {
 # Baseline GWS.GMAIL.14.1v0.1
 #--
 NonCompliantOUs14_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -1514,27 +1511,27 @@ NonCompliantOUs14_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.14.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", TopLevelOU)
+    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.14.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs14_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs14_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs14_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", TopLevelOU)
+    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs14_1) == 0
 }
@@ -1579,7 +1576,7 @@ tests contains {
     "NoSuchEvent": true
 }
 if {
-    Events := FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
+    Events := utils.FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
     count(Events) == 0
 }
 
@@ -1592,9 +1589,9 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
+    Events := utils.FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "[]"
 }
 #--
@@ -1608,14 +1605,14 @@ if {
 # Baseline GWS.GMAIL.16.1v0.1
 #--
 NonCompliantOUs16_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -1623,7 +1620,7 @@ NonCompliantOUs16_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.16.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -1631,21 +1628,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.16.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs16_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs16_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs16_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs16_1) == 0
 }
@@ -1660,13 +1657,13 @@ if {
 # Baseline GWS.GMAIL.17.1v0.1
 #--
 NonCompliantOUs17_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -1675,27 +1672,27 @@ NonCompliantOUs17_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.GMAIL.17.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", TopLevelOU)
+    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GMAIL.17.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs17_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs17_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs17_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", TopLevelOU)
+    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs17_1) == 0
 }

--- a/rego/Gmail.rego
+++ b/rego/Gmail.rego
@@ -1,5 +1,6 @@
 package gmail
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -66,34 +67,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Gmail.rego
+++ b/rego/Gmail.rego
@@ -1,6 +1,7 @@
 package gmail
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -160,12 +161,6 @@ GetEventDomain(Event) := DomainName if {
 
 GetEventDomain(Event) := "None" if {
     not "DOMAIN_NAME" in {Parameter.name | some Parameter in Event.parameters}
-}
-
-GetLastEvent(Events) := Event if {
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 

--- a/rego/Gmail.rego
+++ b/rego/Gmail.rego
@@ -23,6 +23,7 @@ AllDomains contains Domain.domain if {
     some Domain in input.dkim_records
 }
 
+LogEvents := utils.GetEvents("gmail_logs")
 
 ###############
 # GWS.GMAIL.1 #
@@ -33,7 +34,7 @@ AllDomains contains Domain.domain if {
 #--
 NonCompliantOUs1_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -52,7 +53,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -65,7 +66,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_MAIL_DELEGATION_WITHIN_DOMAIN", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -234,7 +235,7 @@ if {
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -254,7 +255,7 @@ tests contains {
 } if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -268,7 +269,7 @@ tests contains {
 }
 if {
     SettingName := "Attachment safety Enable: protect against encrypted attachments from untrusted senders"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -279,7 +280,7 @@ if {
 NonCompliantOUs5_2 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -300,7 +301,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -314,7 +315,7 @@ tests contains {
 }
 if {
     SettingName := "Attachment safety Enable: protect against attachments with scripts from untrusted senders"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_2) == 0
 }
@@ -344,7 +345,7 @@ EncryptedAttachmentSettingDetailsStr(LastEvent) := Description if {
 NonCompliantOUs5_3 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -365,7 +366,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -379,7 +380,7 @@ tests contains {
 }
 if {
     SettingName := "Attachment safety Enable: Protect against anomalous attachment types in emails"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_3) == 0
 }
@@ -390,7 +391,8 @@ if {
 #--
 NonCompliantOUs5_4 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Attachment safety Enable: automatically enables all future added settings", OU)
+    SettingName := "Attachment safety Enable: automatically enables all future added settings"
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -411,7 +413,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Attachment safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -425,7 +427,7 @@ tests contains {
 }
 if {
     SettingName := "Attachment safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_4) == 0
 }
@@ -438,33 +440,36 @@ default NoSuchEvent5_5(_) := true
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := utils.FilterEvents("Attachment safety Encrypted attachment protection setting action", TopLevelOU)
+    SettingName := "Attachment safety Encrypted attachment protection setting action"
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := utils.FilterEvents("Attachment safety Attachment with scripts protection action", TopLevelOU)
+    SettingName := "Attachment safety Attachment with scripts protection action"
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent5_5(TopLevelOU) := false if {
     # No such event...
-    Events := utils.FilterEvents("Attachment safety Anomalous attachment protection setting action", TopLevelOU)
+    SettingName := "Attachment safety Anomalous attachment protection setting action"
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NonCompliantOUs5_5 contains OU if {
     some OU in utils.OUsWithEvents
-    Events_A := utils.FilterEvents("Attachment safety Encrypted attachment protection setting action", OU)
+    Events_A := utils.FilterEvents(LogEvents, "Attachment safety Encrypted attachment protection setting action", OU)
     count(Events_A) > 0
     LastEvent_A := utils.GetLastEvent(Events_A)
 
-    Events_B := utils.FilterEvents("Attachment safety Attachment with scripts protection action", OU)
+    Events_B := utils.FilterEvents(LogEvents, "Attachment safety Attachment with scripts protection action", OU)
     count(Events_B) > 0
     LastEvent_B := utils.GetLastEvent(Events_B)
 
-    Events_C := utils.FilterEvents("Attachment safety Anomalous attachment protection setting action", OU)
+    Events_C := utils.FilterEvents(LogEvents, "Attachment safety Anomalous attachment protection setting action", OU)
     count(Events_C) > 0
     LastEvent_C := utils.GetLastEvent(Events_C)
 
@@ -525,7 +530,7 @@ tests contains {
 NonCompliantOUs6_1 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -546,7 +551,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -560,7 +565,7 @@ tests contains {
 }
 if {
     SettingName := "Links and external images safety Enable: identify links behind shortened URLs"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
 }
@@ -571,7 +576,7 @@ if {
 #--
 NonCompliantOUs6_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", OU)
+    Events := utils.FilterEvents(LogEvents, "Links and external images safety Enable: scan linked images", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -588,7 +593,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", utils.TopLevelOU)
+    SettingName := "Links and external images safety Enable: scan linked images"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -601,7 +607,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("Links and external images safety Enable: scan linked images", utils.TopLevelOU)
+    SettingName := "Links and external images safety Enable: scan linked images"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_2) == 0
 }
@@ -616,7 +623,7 @@ NonCompliantOUs6_3 contains OU if {
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -637,7 +644,7 @@ if {
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -654,7 +661,7 @@ if {
         "Links and external images safety Enable: show warning prompt for click on links to ",
         "unstrusted domains" # NOTE: "unstrusted" really is the spelling the API uses
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_3) == 0
 }
@@ -666,7 +673,7 @@ if {
 NonCompliantOUs6_4 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -687,7 +694,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -701,7 +708,7 @@ tests contains {
 }
 if {
     SettingName := "Links and external images safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_4) == 0
 }
@@ -733,7 +740,7 @@ NonCompliantOUs7_1 contains OU if {
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -754,7 +761,7 @@ if {
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -771,7 +778,7 @@ if {
         "Spoofing and authentication safety Enable: protect against domain spoofing using ",
         "similar domain names"
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_1) == 0
 }
@@ -783,7 +790,7 @@ if {
 NonCompliantOUs7_2 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -804,7 +811,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -818,7 +825,7 @@ tests contains {
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against spoofing of employee names"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_2) == 0
 }
@@ -830,7 +837,7 @@ if {
 NonCompliantOUs7_3 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -851,7 +858,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -865,7 +872,7 @@ tests contains {
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against inbound emails spoofing your domain"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_3) == 0
 }
@@ -877,7 +884,7 @@ if {
 NonCompliantOUs7_4 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -898,7 +905,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -912,7 +919,7 @@ tests contains {
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: protect against any unauthenticated emails"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_4) == 0
 }
@@ -928,7 +935,7 @@ NonCompliantOUs7_5 contains OU if {
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -952,7 +959,7 @@ if {
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -969,7 +976,7 @@ if {
         "Spoofing and authentication safety Enable: protect your Groups from inbound emails ",
         "spoofing your domain"
     ])
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_5) == 0
 }
@@ -987,14 +994,14 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect against domain spoofing based on similar ",
         "domain names action"
     ])
-    Events := utils.FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent7_6(TopLevelOU) := false if {
     # No such event...
     SettingName := "Spoofing and authentication safety Protect against spoofing of employee names action"
-    Events := utils.FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
@@ -1004,14 +1011,14 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect against domain spoofing based on similar ",
         "domain names action"
     ])
-    Events := utils.FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
 NoSuchEvent7_6(TopLevelOU) := false if {
     # No such event...
     SettingName := "Spoofing and authentication safety Protect against any unauthenticated emails action"
-    Events := utils.FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
@@ -1021,7 +1028,7 @@ NoSuchEvent7_6(TopLevelOU) := false if {
         "Spoofing and authentication safety Protect your Groups from inbound emails spoofing ",
         "your domain action"
     ])
-    Events := utils.FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, TopLevelOU)
     count(Events) != 0
 }
 
@@ -1032,22 +1039,22 @@ NonCompliantOUs7_6 contains OU if {
         "Spoofing and authentication safety Protect against domain spoofing based on ",
         "similar domain names action"
     ])
-    EventsA := utils.FilterEvents(SettingA, OU)
+    EventsA := utils.FilterEvents(LogEvents, SettingA, OU)
     count(EventsA) > 0
     LastEventA := utils.GetLastEvent(EventsA)
 
     SettingB := "Spoofing and authentication safety Protect against spoofing of employee names action"
-    EventsB := utils.FilterEvents(SettingB, OU)
+    EventsB := utils.FilterEvents(LogEvents, SettingB, OU)
     count(EventsB) > 0
     LastEventB := utils.GetLastEvent(EventsB)
 
     SettingC := "Spoofing and authentication safety Protect against inbound emails spoofing your domain action"
-    EventsC := utils.FilterEvents(SettingC, OU)
+    EventsC := utils.FilterEvents(LogEvents, SettingC, OU)
     count(EventsC) > 0
     LastEventC := utils.GetLastEvent(EventsC)
 
     SettingD := "Spoofing and authentication safety Protect against any unauthenticated emails action"
-    EventsD := utils.FilterEvents(SettingD, OU)
+    EventsD := utils.FilterEvents(LogEvents, SettingD, OU)
     count(EventsD) > 0
     LastEventD := utils.GetLastEvent(EventsD)
 
@@ -1055,7 +1062,7 @@ NonCompliantOUs7_6 contains OU if {
         "Spoofing and authentication safety Protect your Groups from inbound emails spoofing ",
         "your domain action"
     ])
-    EventsE := utils.FilterEvents(SettingE, OU)
+    EventsE := utils.FilterEvents(LogEvents, SettingE, OU)
     count(EventsE) > 0
     LastEventE := utils.GetLastEvent(EventsE)
 
@@ -1104,7 +1111,7 @@ if {
 NonCompliantOUs7_7 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1125,7 +1132,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEventsNoOU(SettingName)
+    Events := utils.FilterEventsNoOU(LogEvents, SettingName)
     count(Events) == 0
 }
 
@@ -1139,7 +1146,7 @@ tests contains {
 }
 if {
     SettingName := "Spoofing and authentication safety Enable: automatically enables all future added settings"
-    Events := utils.FilterEventsNoOU(SettingName)
+    Events := utils.FilterEventsNoOU(LogEvents, SettingName)
     count(Events) > 0
     Status := count(NonCompliantOUs7_7) == 0
 }
@@ -1169,7 +1176,7 @@ tests contains {
 #--
 NonCompliantOUs8_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_USER_IMPORT", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1188,7 +1195,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1201,7 +1208,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_USER_IMPORT", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs8_1) == 0
 }
@@ -1216,7 +1223,7 @@ if {
 #--
 NonCompliantOUs9_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("IMAP_ACCESS", OU)
+    Events := utils.FilterEvents(LogEvents, "IMAP_ACCESS", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DISABLED"
@@ -1233,7 +1240,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("IMAP_ACCESS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "IMAP_ACCESS", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1246,7 +1253,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("IMAP_ACCESS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "IMAP_ACCESS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_1) == 0
 }
@@ -1257,7 +1264,7 @@ if {
 #--
 NonCompliantOUs9_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_POP_ACCESS", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_POP_ACCESS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1277,7 +1284,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_POP_ACCESS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_POP_ACCESS", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1290,7 +1297,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_POP_ACCESS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_POP_ACCESS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs9_2) == 0
 }
@@ -1306,7 +1313,7 @@ if {
 #--
 NonCompliantOUs10_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_OUTLOOK_SYNC", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
@@ -1323,7 +1330,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1336,7 +1343,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_OUTLOOK_SYNC", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs10_1) == 0
 }
@@ -1353,7 +1360,7 @@ if {
 
 NonCompliantOUs11_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", OU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_AUTOFORWARDING", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1373,7 +1380,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1386,7 +1393,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "ENABLE_EMAIL_AUTOFORWARDING", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs11_1) == 0
 }
@@ -1402,7 +1409,7 @@ if {
 #--
 NonCompliantOUs12_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", OU)
+    Events := utils.FilterEvents(LogEvents, "NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1421,7 +1428,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1434,7 +1441,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "NUMBER_OF_EMAIL_IMAGE_URL_WHITELIST_PATTERNS", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs12_1) == 0
 }
@@ -1450,7 +1457,7 @@ if {
 #--
 NonCompliantOUs13_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", OU)
+    Events := utils.FilterEvents(LogEvents, "OUTBOUND_RELAY_ENABLED", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1469,7 +1476,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1482,7 +1489,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "OUTBOUND_RELAY_ENABLED", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs13_1) == 0
 }
@@ -1498,7 +1505,7 @@ if {
 #--
 NonCompliantOUs14_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", OU)
+    Events := utils.FilterEvents(LogEvents, "OutOfDomainWarningProto disable_untrusted_recipient_warning", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1518,7 +1525,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", utils.TopLevelOU)
+    SettingName := "OutOfDomainWarningProto disable_untrusted_recipient_warning"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1531,7 +1539,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("OutOfDomainWarningProto disable_untrusted_recipient_warning", utils.TopLevelOU)
+    SettingName := "OutOfDomainWarningProto disable_untrusted_recipient_warning"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs14_1) == 0
 }
@@ -1576,7 +1585,7 @@ tests contains {
     "NoSuchEvent": true
 }
 if {
-    Events := utils.FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
+    Events := utils.FilterEventsNoOU(LogEvents, "EMAIL_SPAM_ALLOWLIST")
     count(Events) == 0
 }
 
@@ -1589,7 +1598,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEventsNoOU("EMAIL_SPAM_ALLOWLIST")
+    Events := utils.FilterEventsNoOU(LogEvents, "EMAIL_SPAM_ALLOWLIST")
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     Status := LastEvent.NewValue == "[]"
@@ -1607,7 +1616,7 @@ if {
 NonCompliantOUs16_1 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1628,7 +1637,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1642,7 +1651,7 @@ tests contains {
 }
 if {
     SettingName := "DelayedDeliverySettingsProto disable_delayed_delivery_for_suspicious_email"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs16_1) == 0
 }
@@ -1658,7 +1667,7 @@ if {
 #--
 NonCompliantOUs17_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", OU)
+    Events := utils.FilterEvents(LogEvents, "AttachmentDeepScanningSettingsProto deep_scanning_enabled", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -1679,7 +1688,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", utils.TopLevelOU)
+    SettingName := "AttachmentDeepScanningSettingsProto deep_scanning_enabled"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -1692,7 +1702,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("AttachmentDeepScanningSettingsProto deep_scanning_enabled", utils.TopLevelOU)
+    SettingName := "AttachmentDeepScanningSettingsProto deep_scanning_enabled"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs17_1) == 0
 }

--- a/rego/Gmail.rego
+++ b/rego/Gmail.rego
@@ -1,5 +1,6 @@
 package gmail
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -93,10 +94,6 @@ TopLevelOU := Name if {
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
     Name := ""
-}
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
 }
 
 SettingChangeEvents contains {

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -318,39 +318,39 @@ if {
 #
 # Baseline GWS.GROUPS.7.1v0.1
 #--
-# This sets up for a logical OR between all the settings. If one of them is false,
-# it will trigger the function and add the group to the list.
-IsGroupRestricted(Group) {
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
     Group.whoCanJoin != "CAN_REQUEST_TO_JOIN"
-}
-
-IsGroupRestricted(Group) {
-    Group.whoCanViewMembership != "ALL_MEMBERS_CAN_VIEW"
-}
-
-IsGroupRestricted(Group) {
-    Group.whoCanViewGroup != "ALL_MEMBERS_CAN_VIEW"
-}
-
-IsGroupRestricted(Group) {
-    Group.whoCanModerateMembers != "OWNERS_AND_MANAGERS"
-}
-
-IsGroupRestricted(Group) {
-    Group.allowExternalMembers != "false"
-}
-
-IsGroupRestricted(Group) {
-    Group.whoCanPostMessage != "ALL_MEMBERS_CAN_POST"
-}
-
-IsGroupRestricted(Group) {
-    Group.whoCanContactOwner != "ANYONE_CAN_CONTACT"
 }
 
 NonCompliantGroups7_1 contains Group.name if {
     some Group in input.group_settings
-    IsGroupRestricted(Group)
+    Group.whoCanViewMembership != "ALL_MEMBERS_CAN_VIEW"
+}
+
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    Group.whoCanViewGroup != "ALL_MEMBERS_CAN_VIEW"
+}
+
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    Group.whoCanModerateMembers != "OWNERS_AND_MANAGERS"
+}
+
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    Group.allowExternalMembers != "false"
+}
+
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    Group.whoCanPostMessage != "ALL_MEMBERS_CAN_POST"
+}
+
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    Group.whoCanContactOwner != "ANYONE_CAN_CONTACT"
 }
 
 # if there are no groups, it has to be safe.

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -1,5 +1,6 @@
 package groups
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -55,34 +56,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -1,11 +1,7 @@
 package groups
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.FilterEvents
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.NoSuchEventDetails
 
 NoGroupsDetails(Groups) := "No Groups found in Organization." if {
     count(Groups) == 0
@@ -28,40 +24,40 @@ ReportDetailsGroups(Groups) := Message if {
 # Baseline GWS.GROUPS.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-     some OU in OUsWithEvents
-     Events := FilterEvents("GroupsSharingSettingsProto collaboration_policy", OU)
+     some OU in utils.OUsWithEvents
+     Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", OU)
      count(Events) > 0 # Ignore OUs without any events. We're already
      # asserting that the top-level OU has at least one event; for all
      # other OUs we assume they inherit from a parent OU if they have
      # no events.
-     LastEvent := GetLastEvent(Events)
+     LastEvent := utils.GetLastEvent(Events)
      LastEvent.NewValue != "CLOSED"
  }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto collaboration_policy", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto collaboration_policy", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -76,40 +72,40 @@ if {
 # Baseline GWS.GROUPS.2.1v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonCompliantOUs":NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -123,40 +119,42 @@ if {
 # Baseline GWS.GROUPS.3.1v0.1
 #--
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -171,40 +169,40 @@ if {
 # Baseline GWS.GROUPS.4.1v0.1
 #--
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("GroupsSharingSettingsProto who_can_create_groups", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "ADMIN_ONLY"
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails":NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails":utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto who_can_create_groups", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto who_can_create_groups", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -219,40 +217,40 @@ if {
 # Baseline GWS.GROUPS.5.1v0.1
 #--
 NonCompliantOUs5_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "MEMBERS"
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.5.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.5.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -267,40 +265,40 @@ if {
 # Baseline GWS.GROUPS.6.1v0.1
 #--
 NonCompliantOUs6_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.6.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue":"No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.6.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails":ReportDetailsOUs(NonCompliantOUs6_1),
+    "ReportDetails":utils.ReportDetailsOUs(NonCompliantOUs6_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", TopLevelOU)
+    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
 }

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -3,9 +3,15 @@ import future.keywords
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
-NoGroupsDetails(Groups) = "No Groups found in Organization." if {count(Groups) == 0}
-ReportDetailsGroups(Groups) = "Requirement met in all Groups." if {count(Groups) == 0}
-ReportDetailsGroups(Groups) = Message if {
+NoGroupsDetails(Groups) := "No Groups found in Organization." if {
+    count(Groups) == 0
+}
+
+ReportDetailsGroups(Groups) := "Requirement met in all Groups." if {
+    count(Groups) == 0
+}
+
+ReportDetailsGroups(Groups) := Message if {
     count(Groups) > 0
     Message := concat("", ["Requirement failed in ", concat(", ", Groups), "."])
 }
@@ -13,22 +19,22 @@ ReportDetailsGroups(Groups) = Message if {
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName
     Events := SettingChangeEvents
-    FilteredEvents := [Event | Event = Events[_]; Event.Setting == SettingName]
+    FilteredEvents := {Event | some Event in Events; Event.Setting == SettingName}
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
-    FilteredEvents := [
-        Event | Event = Events[_];
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
+    FilteredEvents := {
+        Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -38,7 +44,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -47,17 +53,17 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Simplest case: if input.tenant_info.topLevelOU is
     # non-empty, it contains the name of the top-level OU.
     input.tenant_info.topLevelOU != ""
-    name := input.tenant_info.topLevelOU
+    Name := input.tenant_info.topLevelOU
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # input.tenant_info.topLevelOU will be empty when
     # no custom OUs have been created, as in this case
     # the top-level OU cannot be determined via the API.
@@ -66,59 +72,63 @@ GetTopLevelOU() := name if {
     # the events and know that it is the top-level OU
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) > 0
-    name := GetLastEvent(SettingChangeEvents).OrgUnit
+    Name := GetLastEvent(SettingChangeEvents).OrgUnit
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Extreme edge case: no custom OUs have been made
     # and the logs are empty. In this case, we really
     # have no way of determining the top-level OU name.
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
-    name := ""
+    Name := ""
 }
-OUsWithEvents[Event.OrgUnit] {
-     Event := SettingChangeEvents[_]
- }
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+
+OUsWithEvents contains Event.OrgUnit if {
+    some Event in SettingChangeEvents
+}
+
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
-    Item := input.groups_logs.items[_] # For each item...
-    Event := Item.events[_] # For each event in the item...
+    "OrgUnit": OrgUnit
+}
+if {
+    some Item in input.groups_logs.items # For each item...
+    some Event in Item.events # For each event in the item...
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | Parameter = Event.parameters[_]] 
-    "NEW_VALUE" in [Parameter.name | Parameter = Event.parameters[_]]
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
-    Setting := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "SETTING_NAME"][0]
-    NewValue := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "NEW_VALUE"][0]
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
+    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
+    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
+    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
 GetLastEvent(Events) := Event if {
     # Because CalendarSharingEvents returns a set instead
     # of an array, we can't just index it and get the last
     # value
-    MaxTs := max([Event.Timestamp | Event = Events[_]])
-    Event := Events[_]
+    MaxTs := max({Event.Timestamp | some Event in Events})
+    some Event in Events
     Event.Timestamp == MaxTs
 }
 
 
 ################
-# Baseline 1   #
+# GWS.GROUPS.1 #
 ################
+
 #
 # Baseline GWS.GROUPS.1.1v0.1
 #--
-
-NonCompliantOUs1_1[OU] {
-     OU := OUsWithEvents[_]
+NonCompliantOUs1_1 contains OU if {
+     some OU in OUsWithEvents
      Events := FilterEventsOU("GroupsSharingSettingsProto collaboration_policy", OU)
      count(Events) > 0 # Ignore OUs without any events. We're already
      # asserting that the top-level OU has at least one event; for all
@@ -128,25 +138,23 @@ NonCompliantOUs1_1[OU] {
      LastEvent.NewValue != "CLOSED"
  }
 
-tests[{ "PolicyId" : "GWS.GROUPS.1.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
+tests[{ "PolicyId": "GWS.GROUPS.1.1v0.1",
+        "Criticality": "Shall",
+        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+        "ActualValue": "No relevant event in the current logs",
+        "RequirementMet": DefaultSafe,
         "NoSuchEvent": true}]{
         DefaultSafe := false
-        TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto collaboration_policy", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default 
+    count(Events) == 0
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.1.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs1_1),
+tests[{ "PolicyId": "GWS.GROUPS.1.1v0.1",
+        "Criticality": "Shall",
+        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
         "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet" : Status,
+        "RequirementMet": Status,
         "NoSuchEvent": false}]{
-        TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto collaboration_policy", TopLevelOU)
     count(Events) > 0
     Status :=count(NonCompliantOUs1_1) == 0
@@ -155,42 +163,46 @@ tests[{ "PolicyId" : "GWS.GROUPS.1.1v0.1",
 
 
 ################
-# Baseline 2   #
+# GWS.GROUPS.2 #
 ################
 
 #
 # Baseline GWS.GROUPS.2.1v0.1
 #--
-
-NonCompliantOUs2_1[OU] {
-     OU := OUsWithEvents[_]
-     Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_external_members", OU)
-     count(Events) > 0 # Ignore OUs without any events. We're already
-     # asserting that the top-level OU has at least one event; for all
-     # other OUs we assume they inherit from a parent OU if they have
-     # no events.
-     LastEvent := GetLastEvent(Events)
-     LastEvent.NewValue != "false"
- }
-tests[{ "PolicyId" : "GWS.GROUPS.2.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
-    DefaultSafe := false
-    TopLevelOU = GetTopLevelOU()
-    Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_external_members", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default 
+NonCompliantOUs2_1 contains OU if {
+    some OU in OUsWithEvents
+    Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_external_members", OU)
+    count(Events) > 0 # Ignore OUs without any events. We're already
+    # asserting that the top-level OU has at least one event; for all
+    # other OUs we assume they inherit from a parent OU if they have
+    # no events.
+    LastEvent := GetLastEvent(Events)
+    LastEvent.NewValue != "false"
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.2.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs2_1),
-        "ActualValue" : {"NonCompliantOUs":NonCompliantOUs2_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.GROUPS.2.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
+    DefaultSafe := false
+    Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_external_members", TopLevelOU)
+    count(Events) == 0
+}
+
+tests contains {
+    "PolicyId": "GWS.GROUPS.2.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ActualValue": {"NonCompliantOUs":NonCompliantOUs2_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_external_members", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -198,13 +210,14 @@ tests[{ "PolicyId" : "GWS.GROUPS.2.1v0.1",
 #--
 
 ################
-# Baseline 3   #
+# GWS.GROUPS.3 #
 ################
+
 #
 # Baseline GWS.GROUPS.3.1v0.1
 #--
-NonCompliantOUs3_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs3_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -214,25 +227,29 @@ NonCompliantOUs3_1[OU] {
     LastEvent.NewValue != "false"
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.3.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.GROUPS.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default 
+    count(Events) == 0
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.3.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs3_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs3_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.GROUPS.3.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
@@ -241,13 +258,14 @@ tests[{ "PolicyId" : "GWS.GROUPS.3.1v0.1",
 
 
 ################
-# Baseline 4   #
+# GWS.GROUPS.4 #
 ################
+
 #
 # Baseline GWS.GROUPS.4.1v0.1
 #--
-NonCompliantOUs4_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs4_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("GroupsSharingSettingsProto who_can_create_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -256,25 +274,30 @@ NonCompliantOUs4_1[OU] {
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "ADMIN_ONLY"
 }
-tests[{ "PolicyId" : "GWS.GROUPS.4.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" :NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+
+tests contains {
+    "PolicyId": "GWS.GROUPS.4.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails":NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto who_can_create_groups", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default 
+    count(Events) == 0
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.4.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs4_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs4_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.GROUPS.4.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("GroupsSharingSettingsProto who_can_create_groups", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
@@ -283,15 +306,14 @@ tests[{ "PolicyId" : "GWS.GROUPS.4.1v0.1",
 
 
 ################
-# Baseline 5   #
+# GWS.GROUPS.5 #
 ################
 
 #
 # Baseline GWS.GROUPS.5.1v0.1
 #--
-
-NonCompliantOUs5_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs5_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("GroupsSharingSettingsProto default_view_topics_access_level", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -300,25 +322,30 @@ NonCompliantOUs5_1[OU] {
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "MEMBERS"
 }
-tests[{ "PolicyId" : "GWS.GROUPS.5.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+
+tests contains {
+    "PolicyId": "GWS.GROUPS.5.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto default_view_topics_access_level", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default
+    count(Events) == 0
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.5.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs5_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs5_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.GROUPS.5.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs5_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("GroupsSharingSettingsProto default_view_topics_access_level", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
@@ -327,14 +354,14 @@ tests[{ "PolicyId" : "GWS.GROUPS.5.1v0.1",
 
 
 ################
-# Baseline 6   #
+# GWS.GROUPS.6 #
 ################
+
 #
 # Baseline GWS.GROUPS.6.1v0.1
 #--
-
-NonCompliantOUs6_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs6_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("GroupsSharingSettingsProto allow_unlisted_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
@@ -343,25 +370,30 @@ NonCompliantOUs6_1[OU] {
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue != "false"
 }
-tests[{ "PolicyId" : "GWS.GROUPS.6.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" :"No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+
+tests contains {
+    "PolicyId": "GWS.GROUPS.6.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue":"No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("GroupsSharingSettingsProto allow_unlisted_groups", TopLevelOU)
-    count(Events) == 0 #If no events were logged, then the default 
+    count(Events) == 0
 }
 
-tests[{ "PolicyId" : "GWS.GROUPS.6.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" :ReportDetailsOUs(NonCompliantOUs6_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs6_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.GROUPS.6.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails":ReportDetailsOUs(NonCompliantOUs6_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("GroupsSharingSettingsProto allow_unlisted_groups", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
@@ -369,66 +401,73 @@ tests[{ "PolicyId" : "GWS.GROUPS.6.1v0.1",
 #--
 
 ################
-# Baseline 7   #
+# GWS.GROUPS.7 #
 ################
+
 #
 # Baseline GWS.GROUPS.7.1v0.1
 #--
-
-# This sets up for a logical OR between all the settings. If one of them is false, it will trigger the function and add the group to the list.
-IsGroupRestricted(group) {
-    group.whoCanJoin != "CAN_REQUEST_TO_JOIN"
+# This sets up for a logical OR between all the settings. If one of them is false,
+# it will trigger the function and add the group to the list.
+IsGroupRestricted(Group) {
+    Group.whoCanJoin != "CAN_REQUEST_TO_JOIN"
 }
 
-IsGroupRestricted(group) {
-    group.whoCanViewMembership != "ALL_MEMBERS_CAN_VIEW"
+IsGroupRestricted(Group) {
+    Group.whoCanViewMembership != "ALL_MEMBERS_CAN_VIEW"
 }
 
-IsGroupRestricted(group) {
-    group.whoCanViewGroup != "ALL_MEMBERS_CAN_VIEW" 
+IsGroupRestricted(Group) {
+    Group.whoCanViewGroup != "ALL_MEMBERS_CAN_VIEW"
 }
 
-IsGroupRestricted(group) {
-    group.whoCanModerateMembers != "OWNERS_AND_MANAGERS"
+IsGroupRestricted(Group) {
+    Group.whoCanModerateMembers != "OWNERS_AND_MANAGERS"
 }
 
-IsGroupRestricted(group) {
-    group.allowExternalMembers != "false" 
+IsGroupRestricted(Group) {
+    Group.allowExternalMembers != "false"
 }
 
-IsGroupRestricted(group) {
-    group.whoCanPostMessage != "ALL_MEMBERS_CAN_POST"
+IsGroupRestricted(Group) {
+    Group.whoCanPostMessage != "ALL_MEMBERS_CAN_POST"
 }
 
-IsGroupRestricted(group) {
-    group.whoCanContactOwner != "ANYONE_CAN_CONTACT"
+IsGroupRestricted(Group) {
+    Group.whoCanContactOwner != "ANYONE_CAN_CONTACT"
 }
 
-NonCompliantGroups7_1[group.name] { 
-    group := input.group_settings[_]
-    IsGroupRestricted(group)
+NonCompliantGroups7_1 contains Group.name if {
+    some Group in input.group_settings
+    IsGroupRestricted(Group)
 }
 
 # if there are no groups, it has to be safe.
-tests[{ "PolicyId" : "GWS.GROUPS.7.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : NoGroupsDetails(Groups),
-        "ActualValue" : NoGroupsDetails(Groups),
-        "RequirementMet" : true,
-        "NoSuchEvent": false}]{
-    Groups := [Group.email | Group = input.group_settings[_]]
+tests contains {
+    "PolicyId": "GWS.GROUPS.7.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoGroupsDetails(Groups),
+    "ActualValue": NoGroupsDetails(Groups),
+    "RequirementMet": true,
+    "NoSuchEvent": false
+}
+if {
+    Groups := {Group.email | some Group in input.group_settings}
     count(Groups) == 0
 }
 
 # if there are groups
-tests[{ "PolicyId" : "GWS.GROUPS.7.1v0.1",
-        "Criticality" : "Should",
-        "ReportDetails" : ReportDetailsGroups(NonCompliantGroups7_1),
-        "ActualValue" : {"NonCompliantGroups": NonCompliantGroups7_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    Groups := [Group.email | Group = input.group_settings[_]]
+tests contains {
+    "PolicyId": "GWS.GROUPS.7.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsGroups(NonCompliantGroups7_1),
+    "ActualValue": {"NonCompliantGroups": NonCompliantGroups7_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
+    Groups := {Group.email | some Group in input.group_settings}
     count(Groups) > 0
-    Status := count(NonCompliantGroups7_1) == 0 
+    Status := count(NonCompliantGroups7_1) == 0
 }
 #--

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -1,5 +1,6 @@
 package groups
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -82,10 +83,6 @@ TopLevelOU := Name if {
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
     Name := ""
-}
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
 }
 
 SettingChangeEvents contains {

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -3,6 +3,8 @@ package groups
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("groups_logs")
+
 NoGroupsDetails(Groups) := "No Groups found in Organization." if {
     count(Groups) == 0
 }
@@ -25,7 +27,7 @@ ReportDetailsGroups(Groups) := Message if {
 #--
 NonCompliantOUs1_1 contains OU if {
      some OU in utils.OUsWithEvents
-     Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", OU)
+     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", OU)
      count(Events) > 0 # Ignore OUs without any events. We're already
      # asserting that the top-level OU has at least one event; for all
      # other OUs we assume they inherit from a parent OU if they have
@@ -44,7 +46,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -57,7 +59,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -73,7 +75,8 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", OU)
+    SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -92,7 +95,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", utils.TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -105,7 +109,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_external_members", utils.TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -120,7 +125,7 @@ if {
 #--
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -140,7 +145,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -154,7 +159,7 @@ tests contains {
 }
 if {
     SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -170,7 +175,7 @@ if {
 #--
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", OU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -189,7 +194,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -202,7 +207,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -218,7 +223,7 @@ if {
 #--
 NonCompliantOUs5_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", OU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto default_view_topics_access_level", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -237,7 +242,8 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", utils.TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto default_view_topics_access_level"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -250,7 +256,8 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("GroupsSharingSettingsProto default_view_topics_access_level", utils.TopLevelOU)
+    SettingName := "GroupsSharingSettingsProto default_view_topics_access_level"
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -266,7 +273,7 @@ if {
 #--
 NonCompliantOUs6_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", OU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -285,7 +292,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -298,7 +305,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
 }

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -1,6 +1,7 @@
 package groups
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -78,15 +79,6 @@ if {
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
     NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-GetLastEvent(Events) := Event if {
-    # Because CalendarSharingEvents returns a set instead
-    # of an array, we can't just index it and get the last
-    # value
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -3,6 +3,8 @@ package meet
 import data.utils
 import future.keywords
 
+LogEvents := utils.GetEvents("meet_logs")
+
 ##############
 # GWS.MEET.1 #
 ##############
@@ -12,7 +14,7 @@ import future.keywords
 #--
 NonCompliantOUs1_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", OU)
+    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
@@ -29,7 +31,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -42,7 +44,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
     # as long as it is not all, this is disabled.
@@ -59,7 +61,7 @@ if {
 #--
 NonCompliantOUs2_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", OU)
+    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
@@ -76,7 +78,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -89,7 +91,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -105,7 +107,7 @@ if {
 #--
 NonCompliantOUs3_1 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", OU)
+    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -122,7 +124,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -135,7 +137,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -151,7 +153,7 @@ if {
 NonCompliantOUs4_1 contains OU if {
     some OU in utils.OUsWithEvents
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(LogEvents, SettingName, OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -169,7 +171,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -183,7 +185,7 @@ tests contains {
 }
 if {
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
+    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -1,11 +1,8 @@
 package meet
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
-
-OUsWithEvents contains Event.OrgUnit if {
-    some Event in SettingChangeEvents
-}
 
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -1,6 +1,7 @@
 package meet
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -92,15 +93,6 @@ if {
     Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
     NewValue := "DELETE_APPLICATION_SETTING"
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-GetLastEvent(Events) := Event if {
-    # Because CalendarSharingEvents returns a set instead
-    # of an array, we can't just index it and get the last
-    # value
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -1,11 +1,7 @@
 package meet
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.FilterEvents
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.NoSuchEventDetails
 
 ##############
 # GWS.MEET.1 #
@@ -15,10 +11,10 @@ import data.utils.NoSuchEventDetails
 # Baseline GWS.MEET.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SafetyDomainLockProto users_allowed_to_join", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -26,27 +22,27 @@ NonCompliantOUs1_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.MEET.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SafetyDomainLockProto users_allowed_to_join", TopLevelOU)
+    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.MEET.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SafetyDomainLockProto users_allowed_to_join", TopLevelOU)
+    Events := utils.FilterEvents("SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
     # as long as it is not all, this is disabled.
@@ -62,10 +58,10 @@ if {
 # Baseline GWS.MEET.2.1v0.1
 #--
 NonCompliantOUs2_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -73,27 +69,27 @@ NonCompliantOUs2_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.MEET.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", TopLevelOU)
+    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.MEET.2.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", TopLevelOU)
+    Events := utils.FilterEvents("SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -108,10 +104,10 @@ if {
 # Baseline GWS.MEET.3.1v0.1
 #--
 NonCompliantOUs3_1 contains OU if {
-    some OU in OUsWithEvents
-    Events := FilterEvents("SafetyModerationLockProto host_management_enabled", OU)
+    some OU in utils.OUsWithEvents
+    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -119,27 +115,27 @@ NonCompliantOUs3_1 contains OU if {
 tests contains {
         "PolicyId": "GWS.MEET.3.1v0.1",
         "Criticality": "Shall",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+        "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
         "ActualValue": "No relevant event in the current logs",
         "RequirementMet": DefaultSafe,
         "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEvents("SafetyModerationLockProto host_management_enabled", TopLevelOU)
+    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.MEET.3.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEvents("SafetyModerationLockProto host_management_enabled", TopLevelOU)
+    Events := utils.FilterEvents("SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -153,11 +149,11 @@ if {
 # Baseline GWS.MEET.4.1v0.1
 #--
 NonCompliantOUs4_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := FilterEvents(SettingName, OU)
+    Events := utils.FilterEvents(SettingName, OU)
     count(Events) > 0
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
@@ -165,7 +161,7 @@ NonCompliantOUs4_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.MEET.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
@@ -173,21 +169,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.MEET.4.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := FilterEvents(SettingName, TopLevelOU)
+    Events := utils.FilterEvents(SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -1,5 +1,6 @@
 package meet
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -42,34 +43,6 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := Name if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) > 0
-    Name := GetLastEvent(SettingChangeEvents).OrgUnit
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(SettingChangeEvents) == 0
-    Name := ""
 }
 
 SettingChangeEvents contains {

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -3,29 +3,29 @@ import future.keywords
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
-OUsWithEvents[Event.OrgUnit] {
-    Event := SettingChangeEvents[_]
+OUsWithEvents contains Event.OrgUnit if {
+    some Event in SettingChangeEvents
 }
 
 FilterEvents(SettingName) := FilteredEvents if {
     # Filter the events by SettingName
     Events := SettingChangeEvents
-    FilteredEvents := [Event | Event = Events[_]; Event.Setting == SettingName]
+    FilteredEvents := [Event | some Event in Events; Event.Setting == SettingName]
 }
 
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
-    FilteredEvents := [
-        Event | Event = Events[_];
+    # Filter the events by both SettingName and OrgUnit
+    Events := FilterEvents(SettingName)
+    FilteredEvents := {
+        Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -35,7 +35,7 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
@@ -44,17 +44,17 @@ FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
 
     # Filter the events by both SettingName and OrgUnit
     Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Simplest case: if input.tenant_info.topLevelOU is
     # non-empty, it contains the name of the top-level OU.
     input.tenant_info.topLevelOU != ""
-    name := input.tenant_info.topLevelOU
+    Name := input.tenant_info.topLevelOU
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # input.tenant_info.topLevelOU will be empty when
     # no custom OUs have been created, as in this case
     # the top-level OU cannot be determined via the API.
@@ -63,36 +63,38 @@ GetTopLevelOU() := name if {
     # the events and know that it is the top-level OU
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) > 0
-    name := GetLastEvent(SettingChangeEvents).OrgUnit
+    Name := GetLastEvent(SettingChangeEvents).OrgUnit
 }
 
-GetTopLevelOU() := name if {
+TopLevelOU := Name if {
     # Extreme edge case: no custom OUs have been made
     # and the logs are empty. In this case, we really
     # have no way of determining the top-level OU name.
     input.tenant_info.topLevelOU == ""
     count(SettingChangeEvents) == 0
-    name := ""
+    Name := ""
 }
 
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
-    Item := input.meet_logs.items[_] # For each item...
-    Event := Item.events[_] # For each event in the item...
+    "OrgUnit": OrgUnit
+}
+if {
+    some Item in input.meet_logs.items # For each item...
+    some Event in Item.events # For each event in the item...
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-    "NEW_VALUE" in [Parameter.name | Parameter = Event.parameters[_]]
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
-    Setting := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "SETTING_NAME"][0]
-    NewValue := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "NEW_VALUE"][0]
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
+    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
+    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
+    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
 # Secondary case that looks for the DELETE_APPLICATION_SETTING events.
@@ -100,32 +102,34 @@ SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
 # minimal special logic, this rule adds the DELETE_APPLICATION_SETTING
 # to the SettingChangeEvents set, with "DELETE_APPLICATION_SETTING" as
 # the NewValue.
-SettingChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
     "Setting": Setting,
-    "OrgUnit": OrgUnit}] {
-
-    Item := input.meet_logs.items[_] # For each item...
-    Event := Item.events[_] # For each event in the item...
+    "OrgUnit": OrgUnit
+}
+if {
+    some Item in input.meet_logs.items # For each item...
+    some Event in Item.events # For each event in the item...
     Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
 
     # Does this event have the parameters we're looking for?
-    "SETTING_NAME" in [Parameter.name | Parameter = Event.parameters[_]] 
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
 
     # Extract the values
-    Setting := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "SETTING_NAME"][0]
+    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
     NewValue := "DELETE_APPLICATION_SETTING"
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
+    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 }
 
 GetLastEvent(Events) := Event if {
     # Because CalendarSharingEvents returns a set instead
     # of an array, we can't just index it and get the last
     # value
-    MaxTs := max([Event.Timestamp | Event = Events[_]])
-    Event := Events[_]
+    MaxTs := max({Event.Timestamp | some Event in Events})
+    some Event in Events
     Event.Timestamp == MaxTs
 }
 
@@ -137,9 +141,8 @@ GetLastEvent(Events) := Event if {
 #
 # Baseline GWS.MEET.1.1v0.1
 #--
-
-NonCompliantOUs1_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs1_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SafetyDomainLockProto users_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -147,27 +150,29 @@ NonCompliantOUs1_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.1.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event for the top-level OU in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.MEET.1.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event for the top-level OU in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("SafetyDomainLockProto users_allowed_to_join", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.1.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.MEET.1.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SafetyDomainLockProto users_allowed_to_join", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
@@ -183,9 +188,8 @@ tests[{
 #
 # Baseline GWS.MEET.2.1v0.1
 #--
-
-NonCompliantOUs2_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs2_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SafetyAccessLockProto meetings_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -193,27 +197,29 @@ NonCompliantOUs2_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.2.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.MEET.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("SafetyAccessLockProto meetings_allowed_to_join", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.2.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs2_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs2_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.MEET.2.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs2_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SafetyAccessLockProto meetings_allowed_to_join", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
@@ -228,9 +234,8 @@ tests[{
 #
 # Baseline GWS.MEET.3.1v0.1
 #--
-
-NonCompliantOUs3_1[OU] {
-    OU := OUsWithEvents[_]
+NonCompliantOUs3_1 contains OU if {
+    some OU in OUsWithEvents
     Events := FilterEventsOU("SafetyModerationLockProto host_management_enabled", OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
@@ -238,27 +243,29 @@ NonCompliantOUs3_1[OU] {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.3.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+        "PolicyId": "GWS.MEET.3.1v0.1",
+        "Criticality": "Shall",
+        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+        "ActualValue": "No relevant event in the current logs",
+        "RequirementMet": DefaultSafe,
+        "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
     Events := FilterEventsOU("SafetyModerationLockProto host_management_enabled", TopLevelOU)
     count(Events) == 0
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.3.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs3_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs3_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
+tests contains {
+    "PolicyId": "GWS.MEET.3.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs3_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
     Events := FilterEventsOU("SafetyModerationLockProto host_management_enabled", TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
@@ -272,38 +279,42 @@ tests[{
 #
 # Baseline GWS.MEET.4.1v0.1
 #--
-
-NonCompliantOUs4_1[OU] {
-    OU := OUsWithEvents[_]
-    Events := FilterEventsOU("Warn for external participants External or unidentified participants in a meeting are given a label", OU)
+NonCompliantOUs4_1 contains OU if {
+    some OU in OUsWithEvents
+    SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
+    Events := FilterEventsOU(SettingName, OU)
     count(Events) > 0
     LastEvent := GetLastEvent(Events)
     LastEvent.NewValue == "false"
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.4.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue" : "No relevant event in the current logs",
-        "RequirementMet" : DefaultSafe,
-        "NoSuchEvent": true}]{
+tests contains {
+    "PolicyId": "GWS.MEET.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
-    Events := FilterEventsOU("Warn for external participants External or unidentified participants in a meeting are given a label", TopLevelOU)
+    SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
+    Events := FilterEventsOU(SettingName, TopLevelOU)
     count(Events) == 0
 }
 
-tests[{
-        "PolicyId" : "GWS.MEET.4.1v0.1",
-        "Criticality" : "Shall",
-        "ReportDetails" : ReportDetailsOUs(NonCompliantOUs4_1),
-        "ActualValue" : {"NonCompliantOUs": NonCompliantOUs4_1},
-        "RequirementMet" : Status,
-        "NoSuchEvent": false}]{
-    TopLevelOU := GetTopLevelOU()
-    Events := FilterEventsOU("Warn for external participants External or unidentified participants in a meeting are given a label", TopLevelOU)
+tests contains {
+    "PolicyId": "GWS.MEET.4.1v0.1",
+    "Criticality": "Shall",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs4_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
+    SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
+    Events := FilterEventsOU(SettingName, TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Sites.rego
+++ b/rego/Sites.rego
@@ -1,5 +1,6 @@
 package sites
 import future.keywords
+import data.utils.TopLevelOU
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -64,33 +65,6 @@ if {
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 
     ServiceName == "Sites"
-}
-
-TopLevelOU := Name if {
-    # Simplest case: if input.tenant_info.topLevelOU is
-    # non-empty, it contains the name of the top-level OU.
-    input.tenant_info.topLevelOU != ""
-    Name := input.tenant_info.topLevelOU
-}
-
-TopLevelOU := OU if {
-    # input.tenant_info.topLevelOU will be empty when
-    # no custom OUs have been created, as in this case
-    # the top-level OU cannot be determined via the API.
-    # Fortunately, in this case, we know there's literally
-    # only one OU, so we can grab the OU listed on any of
-    # the events and know that it is the top-level OU
-    input.tenant_info.topLevelOU == ""
-    some OU in OUsWithEvents
-}
-
-TopLevelOU := Name if {
-    # Extreme edge case: no custom OUs have been made
-    # and the logs are empty. In this case, we really
-    # have no way of determining the top-level OU name.
-    input.tenant_info.topLevelOU == ""
-    count(OUsWithEvents) == 0
-    Name := ""
 }
 
 ###############

--- a/rego/Sites.rego
+++ b/rego/Sites.rego
@@ -1,10 +1,7 @@
 package sites
+
+import data.utils
 import future.keywords
-import data.utils.TopLevelOU
-import data.utils.GetLastEvent
-import data.utils.OUsWithEvents
-import data.utils.ReportDetailsOUs
-import data.utils.NoSuchEventDetails
 
 FilterEventsOU(OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
@@ -70,13 +67,13 @@ if {
 # Baseline GWS.SITES.1.1v0.1
 #--
 NonCompliantOUs1_1 contains OU if {
-    some OU in OUsWithEvents
+    some OU in utils.OUsWithEvents
     Events := FilterEventsOU(OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
     # no events.
-    LastEvent := GetLastEvent(Events)
+    LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "false"
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
@@ -84,27 +81,27 @@ NonCompliantOUs1_1 contains OU if {
 tests contains {
     "PolicyId": "GWS.SITES.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event in the current logs",
     "RequirementMet": DefaultSafe,
     "NoSuchEvent": true
 }
 if {
     DefaultSafe := false
-    Events := FilterEventsOU(TopLevelOU)
+    Events := FilterEventsOU(utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.SITES.1.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := FilterEventsOU(TopLevelOU)
+    Events := FilterEventsOU(utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }

--- a/rego/Sites.rego
+++ b/rego/Sites.rego
@@ -3,136 +3,84 @@ import future.keywords
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
-FilterEvents(ServiceName) := FilteredEvents if
-{
-    Events := ServiceChangeEvents
-    FilteredEvents := [Event | Event = Events[_]; Event.Service == ServiceName]
-}
-
-FilterEventsOU(ServiceName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(OrgUnit) := FilteredEvents if {
     # If there exists at least the root OU and 1 more OU
     # filter out organizational units that don't exist
     input.organizational_unit_names
     count(input.organizational_unit_names) >=2
 
-    # Filter the events by both ServiceName and OrgUnit
-    Events := FilterEvents(ServiceName)
-    FilteredEvents := [
-        Event | Event = Events[_];
+    # Filter the events by OrgUnit
+    Events := ToggleServiceEvents
+    FilteredEvents := {
+        Event | some Event in Events;
         Event.OrgUnit == OrgUnit;
         Event.OrgUnit in input.organizational_unit_names
-    ]
+    }
 }
 
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(OrgUnit) := FilteredEvents if {
     # If only the root OU exists run like normal
     input.organizational_unit_names
     count(input.organizational_unit_names) < 2
 
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
+    # Filter the events by OrgUnit
+    Events := ToggleServiceEvents
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
-FilterEventsOU(SettingName, OrgUnit) := FilteredEvents if {
+FilterEventsOU(OrgUnit) := FilteredEvents if {
     # If OUs variable does not exist run like normal
     not input.organizational_unit_names
 
-    # Filter the events by both SettingName and OrgUnit
-    Events := FilterEvents(SettingName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
-}
-
-ServiceChangeEvents[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
-    "TimestampStr": Item.id.time,
-    "NewValue": NewValue,
-    "Service": Service,
-    "OrgUnit": OrgUnit}] {
-
-    Item := input.sites_logs.items[_] # For each item...
-    Event := Item.events[_] # For each event in the item...
-
-    # Does this event have the parameters we're looking for?
-    "SERVICE_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-    "NEW_VALUE" in [Parameter.name | Parameter = Event.parameters[_]]
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-
-    # Extract the values
-    Service := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "SERVICE_NAME"][0]
-    NewValue := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "NEW_VALUE"][0]
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
+    # Filter the events by OrgUnit
+    Events := ToggleServiceEvents
+    FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
 }
 
 GetLastEvent(Events) := Event if {
-    MaxTs := max([Event.Timestamp | Event = Events[_]])
-    Event := Events[_]
+    MaxTs := max({Event.Timestamp | some Event in Events})
+    some Event in Events
     Event.Timestamp == MaxTs
 }
 
-FilterEventsAlt(EventName) := Events if {
-    # Many of the events for common controls are structured differently.
-    # Instead of having Service_NAME as one of the parameters, the event
-    # name is set to what would normally be the Service name.
-    Events := ServiceChangeEventsAlt with data.EventName as EventName
-}
-
-FilterEventsAltOU(EventName, OrgUnit) := FilteredEvents if {
-    # Filter the events by both EventName and OrgUnit
-    Events := FilterEventsAlt(EventName)
-    FilteredEvents := [Event | Event = Events[_]; Event.OrgUnit == OrgUnit]
-}
-
-GetEventOu(Event) := OrgUnit if {
-    # Helper function that helps the ServiceChange rules always work,
-    # even if the org unit isn't actually listed with the event
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-GetEventOu(Event) := "None" if {
-    not "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-}
-
-ServiceChangeEventsAlt[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
+ToggleServiceEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
     "TimestampStr": Item.id.time,
     "NewValue": NewValue,
-    "OrgUnit": OrgUnit}] {
-    Item := input.sites_logs.items[_] # For each item...
-    Event := Item.events[_]
-    Event.name == data.EventName # Note the data.EventName. This means this
-    # rule will only work if called like this:
-    # ServiceChangeEventsAlt with data.EventName as ExampleEventName
+    "OrgUnit": OrgUnit
+}
+if {
+    some Item in input.sites_logs.items
+    some Event in Item.events
+    Event.name == "TOGGLE_SERVICE_ENABLED"
 
-    "NEW_VALUE" in [Parameter.name | Parameter = Event.parameters[_]]
-    NewValue := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "NEW_VALUE"][0]
-    OrgUnit := GetEventOu(Event)
+    "SERVICE_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "ORG_UNIT_NAME" in [Parameter.name | some Parameter in Event.parameters]
+    "NEW_VALUE" in [Parameter.name | some Parameter in Event.parameters]
+
+    ServiceName := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SERVICE_NAME"][0]
+    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
+    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
+
+    ServiceName == "Sites"
 }
 
-ServiceChangeEventsAlt[{"Timestamp": time.parse_rfc3339_ns(Item.id.time),
-    "TimestampStr": Item.id.time,
-    "NewValue": NewValue,
-    "OrgUnit": OrgUnit}] {
-    Item := input.sites_logs.items[_] # For each item...
-    Event := Item.events[_]
-    Event.name == data.EventName
-
-    not "NEW_VALUE" in [Parameter.name | Parameter = Event.parameters[_]]
-    # If NEW_VALUE isn't a parameter, then the parameter name will be
-    # data.EventName minus the leading CHANGE_ and the trailing S, e.g.,
-    # CHANGE_ALLOWED_TWO_STEP_VERIFICATION_METHODS -> ALLOWED_TWO_STEP_VERIFICATION_METHOD
-    EventName := trim_suffix(trim_prefix(data.EventName, "CHANGE_"), "S")
-    NewValue := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == EventName][0]
-    OrgUnit := GetEventOu(Event)
+OUsWithEvents contains OrgUnit if {
+    some Item in input.sites_logs.items
+    some Event in Item.events
+    some Parameter in Event.parameters
+    Parameter.name == "ORG_UNIT_NAME"
+    OrgUnit := Parameter.value
 }
 
-GetTopLevelOU() := Name if {
+TopLevelOU := Name if {
     # Simplest case: if input.tenant_info.topLevelOU is
     # non-empty, it contains the name of the top-level OU.
     input.tenant_info.topLevelOU != ""
     Name := input.tenant_info.topLevelOU
 }
 
-GetTopLevelOU() := Name if {
+TopLevelOU := OU if {
     # input.tenant_info.topLevelOU will be empty when
     # no custom OUs have been created, as in this case
     # the top-level OU cannot be determined via the API.
@@ -140,40 +88,28 @@ GetTopLevelOU() := Name if {
     # only one OU, so we can grab the OU listed on any of
     # the events and know that it is the top-level OU
     input.tenant_info.topLevelOU == ""
-    count(ServiceChangeEvents) > 0
-    Name := GetLastEvent(ServiceChangeEvents).OrgUnit
+    some OU in OUsWithEvents
 }
 
-GetTopLevelOU() := Name if {
+TopLevelOU := Name if {
     # Extreme edge case: no custom OUs have been made
     # and the logs are empty. In this case, we really
     # have no way of determining the top-level OU name.
     input.tenant_info.topLevelOU == ""
-    count(ServiceChangeEvents) == 0
+    count(OUsWithEvents) == 0
     Name := ""
 }
 
-
-OUsWithEvents[OrgUnit] {
-    Item := input.sites_logs.items[_]
-    Event := Item.events[_]
-    "ORG_UNIT_NAME" in [Parameter.name | Parameter = Event.parameters[_]]
-    OrgUnit := [Parameter.value | Parameter = Event.parameters[_]; Parameter.name == "ORG_UNIT_NAME"][0]
-}
-
-
-################
-# GWS.SITES.1  #
-################
+###############
+# GWS.SITES.1 #
+###############
 
 #
 # Baseline GWS.SITES.1.1v0.1
 #--
-
-NonCompliantOUs1_1[OU] {
-    OU := OUsWithEvents[_]
-    #Events := FilterEventsAltOU("TOGGLE_SERVICE_ENABLED", OU)
-    Events := FilterEventsOU("Sites", OU)
+NonCompliantOUs1_1 contains OU if {
+    some OU in OUsWithEvents
+    Events := FilterEventsOU(OU)
     count(Events) > 0 # Ignore OUs without any events. We're already
     # asserting that the top-level OU has at least one event; for all
     # other OUs we assume they inherit from a parent OU if they have
@@ -183,28 +119,31 @@ NonCompliantOUs1_1[OU] {
     LastEvent.NewValue != "INHERIT_FROM_PARENT"
 }
 
-tests[{
-        "PolicyId" : "GWS.SITES.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
-        "ActualValue": "No relevant event in the current logs",
-        "RequirementMet": DefaultSafe,
-        "NoSuchEvent": true}] {
+tests contains {
+    "PolicyId": "GWS.SITES.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": NoSuchEventDetails(DefaultSafe, TopLevelOU),
+    "ActualValue": "No relevant event in the current logs",
+    "RequirementMet": DefaultSafe,
+    "NoSuchEvent": true
+}
+if {
     DefaultSafe := false
-    TopLevelOU := GetTopLevelOU()
-    Events := FilterEventsOU("Sites", TopLevelOU)
+    Events := FilterEventsOU(TopLevelOU)
     count(Events) == 0
 }
 
-tests[{
-        "PolicyId": "GWS.SITES.1.1v0.1",
-        "Criticality": "Should",
-        "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
-        "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
-        "RequirementMet": Status,
-        "NoSuchEvent": false}] {
-    TopLevelOU := GetTopLevelOU()
-    Events := FilterEventsOU("Sites", TopLevelOU)
+tests contains {
+    "PolicyId": "GWS.SITES.1.1v0.1",
+    "Criticality": "Should",
+    "ReportDetails": ReportDetailsOUs(NonCompliantOUs1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "RequirementMet": Status,
+    "NoSuchEvent": false
+}
+if {
+    Events := FilterEventsOU(TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
+#--

--- a/rego/Sites.rego
+++ b/rego/Sites.rego
@@ -1,6 +1,7 @@
 package sites
 import future.keywords
 import data.utils.TopLevelOU
+import data.utils.GetLastEvent
 import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
@@ -37,12 +38,6 @@ FilterEventsOU(OrgUnit) := FilteredEvents if {
     # Filter the events by OrgUnit
     Events := ToggleServiceEvents
     FilteredEvents := {Event | some Event in Events; Event.OrgUnit == OrgUnit}
-}
-
-GetLastEvent(Events) := Event if {
-    MaxTs := max({Event.Timestamp | some Event in Events})
-    some Event in Events
-    Event.Timestamp == MaxTs
 }
 
 ToggleServiceEvents contains {

--- a/rego/Sites.rego
+++ b/rego/Sites.rego
@@ -1,5 +1,6 @@
 package sites
 import future.keywords
+import data.utils.OUsWithEvents
 import data.utils.ReportDetailsOUs
 import data.utils.NoSuchEventDetails
 
@@ -63,14 +64,6 @@ if {
     OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
 
     ServiceName == "Sites"
-}
-
-OUsWithEvents contains OrgUnit if {
-    some Item in input.sites_logs.items
-    some Event in Item.events
-    some Parameter in Event.parameters
-    Parameter.name == "ORG_UNIT_NAME"
-    OrgUnit := Parameter.value
 }
 
 TopLevelOU := Name if {

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -30,6 +30,10 @@ ReportDetailsOUs(OUs) := Message if {
     Message := concat("", ["Requirement failed in ", concat(", ", OUs), "."])
 }
 
+ReportDetailsBoolean(true) := "Requirement met."
+
+ReportDetailsBoolean(false) := "Requirement not met."
+
 OUsWithEvents contains OrgUnit if {
     some Log in input
     some Item in Log.items
@@ -82,4 +86,175 @@ GetLastEvent(Events) := Event if {
     MaxTs := max({Event.Timestamp | some Event in Events})
     some Event in Events
     Event.Timestamp == MaxTs
+}
+
+# Helper function so that the regular SettingChangeEvents
+# rule will work even for events that don't include the
+# domain name
+GetEventDomain(Event) := DomainName if {
+    "DOMAIN_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    DomainName := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "DOMAIN_NAME"][0]
+}
+
+GetEventDomain(Event) := "None" if {
+    not "DOMAIN_NAME" in {Parameter.name | some Parameter in Event.parameters}
+}
+
+# Helper function so that the regular SettingChangeEvents
+# rule will work even for events that don't include the
+# application name
+GetEventApp(Event) := AppName if {
+    "APPLICATION_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    AppName := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "APPLICATION_NAME"][0]
+}
+
+GetEventApp(Event) := "None" if {
+    not "APPLICATION_NAME" in {Parameter.name | some Parameter in Event.parameters}
+}
+
+# Helper function so that the regular SettingChangeEvents
+# rule will work even for events that don't include the
+# OU name
+GetEventOu(Event) := OrgUnit if {
+    "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    OrgUnit := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "ORG_UNIT_NAME"][0]
+}
+
+GetEventOu(Event) := "None" if {
+    not "ORG_UNIT_NAME" in {Parameter.name | some Parameter in Event.parameters}
+}
+
+
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
+    "TimestampStr": Item.id.time,
+    "NewValue": NewValue,
+    "Setting": Setting,
+    "OrgUnit": OrgUnit,
+    "DomainName": DomainName,
+    "AppName": AppName
+}
+if {
+    some Log in input
+    some Item in Log.items
+    some Event in Item.events
+
+    # Does this event have the parameters we're looking for?
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+
+    # Extract the values that are there for every event    
+    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
+    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
+    
+    # Extract the values that are there for only some of the events
+    DomainName := GetEventDomain(Event)
+    AppName := GetEventApp(Event)
+    OrgUnit := GetEventOu(Event)
+}
+
+# Secondary case that looks for the DELETE_APPLICATION_SETTING events.
+# These events don't have a NEW_VALUE. To make these events work with
+# minimal special logic, this rule adds the DELETE_APPLICATION_SETTING
+# to the SettingChangeEvents set, with "DELETE_APPLICATION_SETTING" as
+# the NewValue.
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
+    "TimestampStr": Item.id.time,
+    "NewValue": NewValue,
+    "Setting": Setting,
+    "OrgUnit": OrgUnit,
+    "DomainName": DomainName,
+    "AppName": AppName
+}
+if {
+    some Log in input
+    some Item in Log.items
+    some Event in Item.events
+    Event.name == "DELETE_APPLICATION_SETTING" # Only look at delete events
+
+    # Does this event have the parameters we're looking for?
+    "SETTING_NAME" in {Parameter.name | some Parameter in Event.parameters}
+
+    NewValue := "DELETE_APPLICATION_SETTING"
+
+    # Extract the values that are there for every event    
+    Setting := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "SETTING_NAME"][0]
+
+    # Extract the values that are there for only some of the events
+    DomainName := GetEventDomain(Event)
+    AppName := GetEventApp(Event)
+    OrgUnit := GetEventOu(Event)
+}
+
+# Special case needed for Common Controls, Russian localization setting
+SettingChangeEvents contains {
+    "Timestamp": time.parse_rfc3339_ns(Item.id.time),
+    "TimestampStr": Item.id.time,
+    "NewValue": NewValue,
+    "OrgUnit": OrgUnit,
+    "Setting": "CHANGE_DATA_LOCALIZATION_FOR_RUSSIA",
+    "AppName": "NA"
+}
+if {
+    some Log in input
+    some Item in Log.items # For each item...
+    some Event in Item.events # For each event in the item...
+
+    Event.name == "CHANGE_DATA_LOCALIZATION_FOR_RUSSIA"
+
+    # Does this event have the parameters we're looking for?
+    "NEW_VALUE" in {Parameter.name | some Parameter in Event.parameters}
+
+    # Extract the values
+    NewValue := [Parameter.value | some Parameter in Event.parameters; Parameter.name == "NEW_VALUE"][0]
+    OrgUnit := GetEventOu(Event)
+}
+
+FilterEvents(SettingName, OrgUnit) := FilteredEvents if {
+    # If there exists at least the root OU and 1 more OU
+    # filter out organizational units that don't exist
+    input.organizational_unit_names
+    count(input.organizational_unit_names) >= 2
+
+    # Filter the events by both SettingName and OrgUnit
+    FilteredEvents := {
+        Event | some Event in SettingChangeEvents;
+        Event.OrgUnit == OrgUnit;
+        Event.Setting == SettingName;
+        Event.OrgUnit in input.organizational_unit_names
+    }
+}
+
+FilterEvents(SettingName, OrgUnit) := FilteredEvents if {
+    # If only the root OU exists run like normal
+    input.organizational_unit_names
+    count(input.organizational_unit_names) < 2
+
+    # Filter the events by both SettingName and OrgUnit
+    FilteredEvents := {
+        Event | some Event in SettingChangeEvents;
+        Event.OrgUnit == OrgUnit;
+        Event.Setting == SettingName
+    }
+}
+
+FilterEvents(SettingName, OrgUnit) := FilteredEvents if {
+    # If OUs variable does not exist run like normal
+    not input.organizational_unit_names
+
+    # Filter the events by both SettingName and OrgUnit
+    FilteredEvents := {
+        Event | some Event in SettingChangeEvents;
+        Event.OrgUnit == OrgUnit;
+        Event.Setting == SettingName
+    }
+}
+
+# Filter the events by just SettingName, ignoring OU
+FilterEventsNoOU(SettingName) := FilteredEvents if {
+    FilteredEvents := {
+        Event | some Event in SettingChangeEvents;
+        Event.Setting == SettingName
+    }
 }

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -38,3 +38,42 @@ OUsWithEvents contains OrgUnit if {
     Parameter.name == "ORG_UNIT_NAME"
     OrgUnit := Parameter.value
 }
+
+TopLevelOU := Name if {
+    # Simplest case: if input.tenant_info.topLevelOU is
+    # non-empty, it contains the name of the top-level OU.
+    input.tenant_info.topLevelOU != ""
+    Name := input.tenant_info.topLevelOU
+}
+
+TopLevelOU := OU if {
+    # input.tenant_info.topLevelOU will be empty when
+    # no custom OUs have been created, as in this case
+    # the top-level OU cannot be determined via the API.
+    # Fortunately, in this case, we know there's literally
+    # only one OU, so we can grab the OU listed on any of
+    # the events and know that it is the top-level OU
+    input.tenant_info.topLevelOU == ""
+    count(OUsWithEvents) == 1
+    some OU in OUsWithEvents
+}
+
+TopLevelOU := Name if {
+    # Extreme edge case: input.tenant_info.topLevelOU is empty
+    # because no custom OUs currently exist, but multiple OUs
+    # are present in the events, likely due to an custom OU
+    # that was deleted. In this case, we have no way of determining
+    # which of OUs is the current OU.
+    input.tenant_info.topLevelOU == ""
+    count(OUsWithEvents) > 1
+    Name := ""
+}
+
+TopLevelOU := Name if {
+    # Extreme edge case: no custom OUs have been made
+    # and the logs are empty. In this case, we really
+    # have no way of determining the top-level OU name.
+    input.tenant_info.topLevelOU == ""
+    count(OUsWithEvents) == 0
+    Name := ""
+}

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -21,7 +21,10 @@ NoSuchEventDetails(DefaultSafe, TopLevelOU) := Message if {
     ])
 }
 
-ReportDetailsOUs(OUs) := "Requirement met in all OUs." if {count(OUs) == 0}
+ReportDetailsOUs(OUs) := "Requirement met in all OUs." if {
+    count(OUs) == 0
+}
+
 ReportDetailsOUs(OUs) := Message if {
     count(OUs) > 0
     Message := concat("", ["Requirement failed in ", concat(", ", OUs), "."])

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -29,3 +29,12 @@ ReportDetailsOUs(OUs) := Message if {
     count(OUs) > 0
     Message := concat("", ["Requirement failed in ", concat(", ", OUs), "."])
 }
+
+OUsWithEvents contains OrgUnit if {
+    some Log in input
+    some Item in Log.items
+    some Event in Item.events
+    some Parameter in Event.parameters
+    Parameter.name == "ORG_UNIT_NAME"
+    OrgUnit := Parameter.value
+}

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -77,3 +77,9 @@ TopLevelOU := Name if {
     count(OUsWithEvents) == 0
     Name := ""
 }
+
+GetLastEvent(Events) := Event if {
+    MaxTs := max({Event.Timestamp | some Event in Events})
+    some Event in Events
+    Event.Timestamp == MaxTs
+}

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -253,6 +253,6 @@ FilterEvents(SettingName, OrgUnit) := FilteredEvents if {
 
 # Filter the events by just SettingName, ignoring OU
 FilterEventsNoOU(SettingName) := {
-        Event | some Event in SettingChangeEvents;
-        Event.Setting == SettingName
+    Event | some Event in SettingChangeEvents;
+    Event.Setting == SettingName
 }

--- a/rego/Utils.rego
+++ b/rego/Utils.rego
@@ -252,9 +252,7 @@ FilterEvents(SettingName, OrgUnit) := FilteredEvents if {
 }
 
 # Filter the events by just SettingName, ignoring OU
-FilterEventsNoOU(SettingName) := FilteredEvents if {
-    FilteredEvents := {
+FilterEventsNoOU(SettingName) := {
         Event | some Event in SettingChangeEvents;
         Event.Setting == SettingName
-    }
 }


### PR DESCRIPTION
## 🗣 Description ##
- Move all shared rules/functions to the Utils.rego file
- Make all Rego code v1 compliant
- Make all Rego code conform to our Regal style checks

### 💭 Motivation and context
Closes #117.
Closes #69.

## 🧪 Testing
Tests I performed:
- `.\regal.exe lint --format github rego Testing` passes (using the config file in the .regal folder)
- `.\opa_windows_amd64.exe check --rego-v1 rego Testing` passes
- Rego unit tests all pass
- Ran ScubaGoggles for all products on both main and this branch, no diff observed

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [x] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
