### PR TITLE
Addresses comments in issue 139

### DIFF
--- a/baselines/Gmail Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Gmail Minimum Viable Secure Configuration Baseline v0.1.md
@@ -696,7 +696,7 @@ To configure the settings for Spoofing and Authentication Protection:
 
 ## 8. User Email Uploads
 
-This section enables users to import their email and contacts from non-Google webmail accounts such as Yahoo!, Hotmail, or AOL.
+This section deals with the feature that allows users to upload emails.
 
 ### Policies
 


### PR DESCRIPTION
Fixed the wording for policy group 8 within the Gmail baseline to address the comments in 139. Fixes #139.