### PR TITLE
Refactor DNS Code

### DIFF
--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -21,8 +21,7 @@ EVENTS = {
         'CREATE_APPLICATION_SETTING',
         'DELETE_APPLICATION_SETTING'
     ],
-    'commoncontrols':
-    [
+    'commoncontrols': [
         'CREATE_APPLICATION_SETTING',
         'CHANGE_APPLICATION_SETTING',
         'TOGGLE_CAA_ENABLEMENT',
@@ -41,20 +40,20 @@ EVENTS = {
         'DELETE_APPLICATION_SETTING',
         'CHANGE_DATA_LOCALIZATION_FOR_RUSSIA'
     ],
-    'drive':[
+    'drive': [
         'CHANGE_APPLICATION_SETTING',
         'CHANGE_DOCS_SETTING',
         'DELETE_APPLICATION_SETTING'
     ],
-    'gmail':[
+    'gmail': [
         'CHANGE_GMAIL_SETTING',
         'CHANGE_APPLICATION_SETTING',
         'CHANGE_EMAIL_SETTING',
         'CREATE_APPLICATION_SETTING',
         'DELETE_APPLICATION_SETTING'
     ],
-    'groups':['CHANGE_APPLICATION_SETTING'],
-    'meet':[
+    'groups': ['CHANGE_APPLICATION_SETTING'],
+    'meet': [
         'CHANGE_APPLICATION_SETTING',
         'CREATE_APPLICATION_SETTING',
         'DELETE_APPLICATION_SETTING'
@@ -87,6 +86,14 @@ selectors = ["google", "selector1", "selector2"]
 #    beginning of the domain name up to the first period
 #
 
+
+# A global variable used to indicate the preferred DoH server.
+# Initialize to empty string to indicate that we don't yet know the
+# preferred server. Will be set when the Select-DohServer function is
+# called.
+doh_server = ""
+
+
 def robust_query(qname : str, max_tries : int = 2) -> dict:
     '''
     Requests the TXT record for the given qname. First tries to make
@@ -101,7 +108,7 @@ def robust_query(qname : str, max_tries : int = 2) -> dict:
     # First attempt the query over traditional DNS
     result = traditional_query(qname, max_tries)
     success = result['success']
-    trad_empty_or_nx = result['trad_empty_or_nx']
+    trad_empty = result['trad_empty']
     answers = result['answers']
     log_entries = result['log_entries']
 
@@ -113,14 +120,14 @@ def robust_query(qname : str, max_tries : int = 2) -> dict:
         log_entries.extend(result['log_entries'])
 
     # There are three possible outcomes of this function:
-    # - Full confidence: we know conclusively that the domain exists or not, either via a positive
-    # answer from traditional DNS, an answer from DoH, or NXDomain from DoH.
-    # - Medium confidence: domain likely doesn't exist, but there is some doubt (NXDomain or no
-    # answer from traditional DNS and DoH failed).
+    # - Full confidence: we know conclusively that the domain exists or not, either via a non-empty
+    # answer from traditional DNS or an answer from DoH.
+    # - Medium confidence: domain likely doesn't exist, but there is some doubt (empty answer from
+    # traditonal DNS and DoH failed).
     # No confidence: all queries failed. Throw an exception in this case.
     if success:
         return {"Answers": answers, "HighConfidence": True, "LogEntries": log_entries}
-    if trad_empty_or_nx:
+    if trad_empty:
         return {"Answers": answers, "HighConfidence": False, "LogEntries": log_entries}
     log = '\n'.join([json.dumps(entry) for entry in log_entries])
     raise Exception(f"Failed to resolve {qname}. \n{log}")
@@ -136,11 +143,12 @@ def traditional_query(qname, max_tries):
     answers = []
     log_entries = []
     success = False
-    trad_empty_or_nx = False
+    trad_empty = False
 
     while try_number < max_tries:
         try_number += 1
         try:
+            x/2
             # No exception was thrown, we got our answer, so break out of the retry loop and set
             # success to True, no need to retry the traditional query or retry with DoH.
             response = dns.resolver.resolve(qname, "TXT")
@@ -160,18 +168,16 @@ def traditional_query(qname, max_tries):
             # this was not a transient failure. Don't set success to True though, as we want to
             # retry this query from a public resolver, in case the internal DNS server returns a
             # different answer than what is served to the public (i.e., split horizon DNS).
-            trad_empty_or_nx = True
+            trad_empty = True
             log_entries.append({
                 "query_name": qname,
                 "query_method": "traditional",
                 "query_result": "Query returned 0 txt records"})
             break
         except dns.resolver.NXDOMAIN:
-            # The server returned NXDomain, no need to retry the traditional query, this was not
-            # a transient failure. Don't set success to True though, as we want to retry this
-            # query from a public resolver, in case the internal DNS server returns a different
-            # answer than what is served to the public (i.e., split horizon DNS).
-            trad_empty_or_nx = True
+                # The server returned NXDomain, no need to retry the traditional query or retry with
+                # DoH, this was not a transient failure. Break out of loop and set success to True
+            success = True
             log_entries.append({
                 "query_name": qname,
                 "query_method": "traditional",
@@ -184,10 +190,36 @@ def traditional_query(qname, max_tries):
                 "query_method": "traditional",
                 "query_result": f"Query resulted in exception {exception}"})
 
-    return {"success": success,
-        "trad_empty_or_nx": trad_empty_or_nx,
+    return {
+        "success": success,
+        "trad_empty": trad_empty,
         "answers": answers,
-        "log_entries": log_entries}
+        "log_entries": log_entries
+    }
+
+def get_doh_server() -> str:
+    """Iterates through several DoH servers. Returns the first successful server.
+    If none are successful, returns None.
+    """
+    doh_servers = ["cloudflare-dns.com", "[2606:4700:4700::1111]", "1.1.1.1"]
+    preferred_server = None
+    for server in doh_servers:
+        try:
+            # Attempt to resolve a.root-servers.net over DoH. The domain chosen is somewhat
+            # arbitrary, as we don't care what the answer is, only if the query succeeds/fails.
+            # a.root-servers.net, the address of one of the DNS root servers, was chosen as a
+            # benign, highly-available domain.
+            print("DoH query")
+            uri = f"https://{server}/dns-query?name=a.root-servers.net"
+            headers = {"accept":"application/dns-json"}
+            requests.get(uri, headers=headers, timeout=2).json()
+            # No error was thrown, return this server
+            preferred_server = server
+            break
+        except:
+            # This server didn't work, try the next one
+            continue
+    return preferred_server
 
 def doh_query(qname, max_tries):
     '''
@@ -196,50 +228,65 @@ def doh_query(qname, max_tries):
     :param qname: The query name (ie domain name).
     :param max_tries: The number of times to retry the query.
     '''
+    global doh_server
+
+    log_entries = []
     try_number = 0
     answers = []
-    log_entries = []
     success = False
-    while try_number < max_tries:
-        try_number += 1
-        uri = f"https://1.1.1.1/dns-query?name={qname})&type=txt"
-        headers = {"accept":"application/dns-json"}
-        try:
-            response = requests.get(uri, headers=headers, timeout=5).json()
-            if response['Status'] == 0:
-                # 0 indicates there was no error
+
+    if doh_server == "":
+        doh_server = get_doh_server()
+    if doh_server is None:
+        # None of the DoH servers are accessible
+        log_entries.append({
+            "query_name": qname,
+            "query_method": "DoH",
+            "query_result": "NA, DoH servers unreachable"
+        })
+    else:
+        # DoH is available, query for the domain
+        while try_number < max_tries:
+            try_number += 1
+            uri = f"https://{doh_server}/dns-query?name={qname}&type=txt"
+            headers = {"accept":"application/dns-json"}
+            try:
+                print("DoH query")
+                response = requests.get(uri, headers=headers, timeout=5).json()
+                if response['Status'] == 0:
+                    # 0 indicates there was no error
+                    log_entries.append({
+                        "query_name": qname,
+                        "query_method": "DoH",
+                        "query_result": f"Query returned {len(response['Answer'])} txt records"})
+                    for answer in response['Answer']:
+                        answers.append(answer['data'].replace('"', ''))
+                    success = True
+                    break
+                if response['Status'] == 3:
+                    # 3 indicates NXDomain. The DNS query succeeded, but the domain did not exist.
+                    # Set success to True, because event though the domain does not exist, the
+                    # query succeeded, and this came from an external resolver so split horizon is
+                    # not an issue here.
+                    log_entries.append({
+                        "query_name": qname,
+                        "query_method": "DoH",
+                        "query_result": "Query returned NXDomain"})
+                    success = True
+                    break
+                # The remainder of the response codes indicate that the query did not succeed.
+                # Retry if we haven't reached max_tries.
                 log_entries.append({
                     "query_name": qname,
                     "query_method": "DoH",
-                    "query_result": f"Query returned {len(response['Answer'])} txt records"})
-                for answer in response['Answers']:
-                    answers.append(answer['data'].replace('"', ''))
-                success = True
-                break
-            if response['Status'] == 3:
-                # 3 indicates NXDomain. The DNS query succeeded, but the domain did not exist.
-                # Set success to True, because event though the domain does not exist, the
-                # query succeeded, and this came from an external resolver so split horizon is
-                # not an issue here.
+                    "query_result": f"Query returned response code {response['Status']}"})
+            except Exception as exception:
+                # The DoH query failed, likely due to a network issue. Retry if we haven't reached
+                # $MaxTries.
                 log_entries.append({
                     "query_name": qname,
                     "query_method": "DoH",
-                    "query_result": "Query returned NXDomain"})
-                success = True
-                break
-            # The remainder of the response codes indicate that the query did not succeed.
-            # Retry if we haven't reached max_tries.
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "DoH",
-                "query_result": f"Query returned response code {response['Status']}"})
-        except Exception as exception:
-            # The DoH query failed, likely due to a network issue. Retry if we haven't reached
-            # $MaxTries.
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "DoH",
-                "query_result": f"Query resulted in exception {exception}"})
+                    "query_result": f"Query resulted in exception {exception}"})
     return {"success": success, "answers": answers, "log_entries": log_entries}
 
 def get_spf_records(domains: list) -> list:
@@ -261,7 +308,7 @@ def get_spf_records(domains: list) -> list:
         })
     if n_low_confidence > 0:
         warnings.warn(f"get_spf_records: for {n_low_confidence} domain(s), \
-the traditional DNS queries returned either NXDomain or an empty answer \
+the traditional DNS queries returned an empty answer \
 section and the DoH queries failed. Will assume SPF not configured, but \
 can't guarantee that failure isn't due to something like split horizon DNS. \
 See ProviderSettingsExport.json under 'spf_records' for more details.", RuntimeWarning)
@@ -298,7 +345,7 @@ def get_dkim_records(domains : list) -> list:
 
     if n_low_confidence > 0:
         warnings.warn(f"get_dkim_records: for {n_low_confidence} domain(s), \
-the traditional DNS queries returned either NXDomain or an empty answer \
+the traditional DNS queries returned an empty answer \
 section and the DoH queries failed. Will assume DKIM not configured, but \
 can't guarantee that failure isn't due to something like split horizon DNS. \
 See ProviderSettingsExport.json under 'dkim_records' for more details.", RuntimeWarning)
@@ -333,7 +380,7 @@ def get_dmarc_records(domains : list) -> list:
         })
     if n_low_confidence > 0:
         warnings.warn(f"get_dmarc_records: for {n_low_confidence} domain(s), \
-the traditional DNS queries returned either NXDomain or an empty answer \
+the traditional DNS queries returned an empty answer \
 section and the DoH queries failed. Will assume DMARC not configured, but \
 can't guarantee that failure isn't due to something like split horizon DNS. \
 See ProviderSettingsExport.json under 'dmarc_records' for more details.", RuntimeWarning)

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -2,13 +2,11 @@
 provider.py is where the GWS api calls are made.
 
 """
-import json
 import warnings
-import dns.resolver
-import requests
 from tqdm import tqdm
 
 from scubagoggles.utils import create_subset_inverted_dict, create_key_to_list, merge_dicts
+from scubagoggles.robust_dns import RobustDNSClient
 
 EVENTS = {
     'calendar': [
@@ -86,205 +84,7 @@ selectors = ["google", "selector1", "selector2"]
 #    beginning of the domain name up to the first period
 #
 
-
-# A global variable used to indicate the preferred DoH server.
-# Initialize to empty string to indicate that we don't yet know the
-# preferred server. Will be set when the Select-DohServer function is
-# called.
-doh_server = ""
-
-
-def robust_query(qname : str, max_tries : int = 2) -> dict:
-    '''
-    Requests the TXT record for the given qname. First tries to make
-    the query over traditional DNS but retries over DoH in the event of
-    failure.
-
-    :param qname: The query name (ie domain name).
-    :param max_tries: The number of times to retry each kind of query.
-            If all queries are unsuccessful, the traditional queries and
-            the DoH queries will each be made $MaxTries times. Default 2.
-    '''
-    # First attempt the query over traditional DNS
-    result = traditional_query(qname, max_tries)
-    success = result['success']
-    trad_empty = result['trad_empty']
-    answers = result['answers']
-    log_entries = result['log_entries']
-
-    if not success:
-        # The traditional DNS query(ies) failed. Retry with DoH
-        result = doh_query(qname, max_tries)
-        success = result['success']
-        answers.extend(result['answers'])
-        log_entries.extend(result['log_entries'])
-
-    # There are three possible outcomes of this function:
-    # - Full confidence: we know conclusively that the domain exists or not, either via a non-empty
-    # answer from traditional DNS or an answer from DoH.
-    # - Medium confidence: domain likely doesn't exist, but there is some doubt (empty answer from
-    # traditonal DNS and DoH failed).
-    # No confidence: all queries failed. Throw an exception in this case.
-    if success:
-        return {"Answers": answers, "HighConfidence": True, "LogEntries": log_entries}
-    if trad_empty:
-        return {"Answers": answers, "HighConfidence": False, "LogEntries": log_entries}
-    log = '\n'.join([json.dumps(entry) for entry in log_entries])
-    raise Exception(f"Failed to resolve {qname}. \n{log}")
-
-def traditional_query(qname, max_tries):
-    '''
-    Requests the TXT record for the given qname over DoH.
-
-        :param qname: The query name (ie domain name).
-        :param max_tries: The number of times to retry the query.
-    '''
-    try_number = 0
-    answers = []
-    log_entries = []
-    success = False
-    trad_empty = False
-
-    while try_number < max_tries:
-        try_number += 1
-        try:
-            # No exception was thrown, we got our answer, so break out of the retry loop and set
-            # success to True, no need to retry the traditional query or retry with DoH.
-            response = dns.resolver.resolve(qname, "TXT")
-            for answer in response:
-                answers.append(answer.to_text().strip('"')) # Strip
-                # the quotes because the actual response comes wrapped in
-                # quotes, resulting in duplicate quotes in the json output
-            success = True
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "traditional",
-                "query_result": f"Query returned {len(response)} txt records"})
-            break
-        except dns.resolver.NoAnswer:
-            # The answer section was empty. This usually means that while the domain exists, but
-            # there are no records of the requested type. No need to retry the traditional query,
-            # this was not a transient failure. Don't set success to True though, as we want to
-            # retry this query from a public resolver, in case the internal DNS server returns a
-            # different answer than what is served to the public (i.e., split horizon DNS).
-            trad_empty = True
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "traditional",
-                "query_result": "Query returned 0 txt records"})
-            break
-        except dns.resolver.NXDOMAIN:
-                # The server returned NXDomain, no need to retry the traditional query or retry with
-                # DoH, this was not a transient failure. Break out of loop and set success to True
-            success = True
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "traditional",
-                "query_result": "Query returned NXDOMAIN"})
-            break
-        except Exception as exception:
-            # The query failed, possibly a transient failure. Retry if we haven't reached max_tries.
-            log_entries.append({
-                "query_name": qname,
-                "query_method": "traditional",
-                "query_result": f"Query resulted in exception {exception}"})
-
-    return {
-        "success": success,
-        "trad_empty": trad_empty,
-        "answers": answers,
-        "log_entries": log_entries
-    }
-
-def get_doh_server() -> str:
-    """Iterates through several DoH servers. Returns the first successful server.
-    If none are successful, returns None.
-    """
-    doh_servers = ["cloudflare-dns.com", "[2606:4700:4700::1111]", "1.1.1.1"]
-    preferred_server = None
-    for server in doh_servers:
-        try:
-            # Attempt to resolve a.root-servers.net over DoH. The domain chosen is somewhat
-            # arbitrary, as we don't care what the answer is, only if the query succeeds/fails.
-            # a.root-servers.net, the address of one of the DNS root servers, was chosen as a
-            # benign, highly-available domain.
-            uri = f"https://{server}/dns-query?name=a.root-servers.net"
-            headers = {"accept":"application/dns-json"}
-            requests.get(uri, headers=headers, timeout=2).json()
-            # No error was thrown, return this server
-            preferred_server = server
-            break
-        except:
-            # This server didn't work, try the next one
-            continue
-    return preferred_server
-
-def doh_query(qname, max_tries):
-    '''
-    Requests the TXT record for the given qname over DoH.
-
-    :param qname: The query name (ie domain name).
-    :param max_tries: The number of times to retry the query.
-    '''
-    global doh_server
-
-    log_entries = []
-    try_number = 0
-    answers = []
-    success = False
-
-    if doh_server == "":
-        doh_server = get_doh_server()
-    if doh_server is None:
-        # None of the DoH servers are accessible
-        log_entries.append({
-            "query_name": qname,
-            "query_method": "DoH",
-            "query_result": "NA, DoH servers unreachable"
-        })
-    else:
-        # DoH is available, query for the domain
-        while try_number < max_tries:
-            try_number += 1
-            uri = f"https://{doh_server}/dns-query?name={qname}&type=txt"
-            headers = {"accept":"application/dns-json"}
-            try:
-                response = requests.get(uri, headers=headers, timeout=5).json()
-                if response['Status'] == 0:
-                    # 0 indicates there was no error
-                    log_entries.append({
-                        "query_name": qname,
-                        "query_method": "DoH",
-                        "query_result": f"Query returned {len(response['Answer'])} txt records"})
-                    for answer in response['Answer']:
-                        answers.append(answer['data'].replace('"', ''))
-                    success = True
-                    break
-                if response['Status'] == 3:
-                    # 3 indicates NXDomain. The DNS query succeeded, but the domain did not exist.
-                    # Set success to True, because event though the domain does not exist, the
-                    # query succeeded, and this came from an external resolver so split horizon is
-                    # not an issue here.
-                    log_entries.append({
-                        "query_name": qname,
-                        "query_method": "DoH",
-                        "query_result": "Query returned NXDomain"})
-                    success = True
-                    break
-                # The remainder of the response codes indicate that the query did not succeed.
-                # Retry if we haven't reached max_tries.
-                log_entries.append({
-                    "query_name": qname,
-                    "query_method": "DoH",
-                    "query_result": f"Query returned response code {response['Status']}"})
-            except Exception as exception:
-                # The DoH query failed, likely due to a network issue. Retry if we haven't reached
-                # $MaxTries.
-                log_entries.append({
-                    "query_name": qname,
-                    "query_method": "DoH",
-                    "query_result": f"Query resulted in exception {exception}"})
-    return {"success": success, "answers": answers, "log_entries": log_entries}
+DNSClient = RobustDNSClient()
 
 def get_spf_records(domains: list) -> list:
     '''
@@ -295,7 +95,7 @@ def get_spf_records(domains: list) -> list:
     results = []
     n_low_confidence = 0
     for domain in domains:
-        result = robust_query(domain)
+        result = DNSClient.query(domain)
         if not result['HighConfidence']:
             n_low_confidence += 1
         results.append({
@@ -323,7 +123,7 @@ def get_dkim_records(domains : list) -> list:
         qnames = [f"{selector}._domainkey.{domain}" for selector in selectors]
         log_entries = []
         for qname in qnames:
-            result = robust_query(qname)
+            result = DNSClient.query(qname)
             log_entries.extend(result['LogEntries'])
             if len(result['Answers']) == 0:
                 # The DKIM record does not exist with this selector, we need to try again with
@@ -359,14 +159,14 @@ def get_dmarc_records(domains : list) -> list:
     for domain in domains:
         log_entries = []
         qname = f"_dmarc.{domain}"
-        result = robust_query(qname)
+        result = DNSClient.query(qname)
         log_entries.extend(result['LogEntries'])
         if len(result["Answers"]) == 0:
             # The domain does not exist. If the record is not available at the full domain
             # level, we need to check at the organizational domain level.
             labels = domain.split(".")
             org_domain = f"{labels[-2]}.{labels[-1]}"
-            result = robust_query(f"_dmarc.{org_domain}")
+            result = DNSClient.query(f"_dmarc.{org_domain}")
             log_entries.extend(result['LogEntries'])
         if not result['HighConfidence']:
             n_low_confidence += 1
@@ -389,7 +189,7 @@ def get_dnsinfo(service):
 
     :param service: a directory_v1 service instance
     '''
-    output = {"spf_records": [], "dkim_records": [], "dmarc_records": []}
+    output = {"domains": [], "spf_records": [], "dkim_records": [], "dmarc_records": []}
 
     # Determine the tenant's domains via the API
     response = service.domains().list(customer="my_customer").execute()
@@ -398,6 +198,8 @@ def get_dnsinfo(service):
     if len(domains) == 0:
         warnings.warn("No domains found.", RuntimeWarning)
         return output
+
+    output["domains"].extend(domains)
 
     try:
         output["spf_records"] = get_spf_records(domains)

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -148,7 +148,6 @@ def traditional_query(qname, max_tries):
     while try_number < max_tries:
         try_number += 1
         try:
-            x/2
             # No exception was thrown, we got our answer, so break out of the retry loop and set
             # success to True, no need to retry the traditional query or retry with DoH.
             response = dns.resolver.resolve(qname, "TXT")
@@ -209,7 +208,6 @@ def get_doh_server() -> str:
             # arbitrary, as we don't care what the answer is, only if the query succeeds/fails.
             # a.root-servers.net, the address of one of the DNS root servers, was chosen as a
             # benign, highly-available domain.
-            print("DoH query")
             uri = f"https://{server}/dns-query?name=a.root-servers.net"
             headers = {"accept":"application/dns-json"}
             requests.get(uri, headers=headers, timeout=2).json()
@@ -251,7 +249,6 @@ def doh_query(qname, max_tries):
             uri = f"https://{doh_server}/dns-query?name={qname}&type=txt"
             headers = {"accept":"application/dns-json"}
             try:
-                print("DoH query")
                 response = requests.get(uri, headers=headers, timeout=5).json()
                 if response['Status'] == 0:
                     # 0 indicates there was no error

--- a/scubagoggles/robust_dns.py
+++ b/scubagoggles/robust_dns.py
@@ -1,0 +1,206 @@
+'''Code for running robust DNS queries, including logic for retries over both the traditional DNS
+as well as DNS over HTTPS (DoH)'''
+
+import json
+import dns.resolver
+import requests
+
+class RobustDNSClient:
+    '''Class used to run robust DNS queries.'''
+    def __init__(self):
+        # doh_server is a variable used to indicate the preferred DoH server.
+        # Initialize to empty string to indicate that we don't yet know the
+        # preferred server. Will be set when the Select-DohServer function is
+        # called.
+        self.doh_server = ""
+
+    def query(self, qname : str, max_tries : int = 2) -> dict:
+        '''
+        Requests the TXT record for the given qname. First tries to make
+        the query over traditional DNS but retries over DoH in the event of
+        failure.
+
+        :param qname: The query name (ie domain name).
+        :param max_tries: The number of times to retry each kind of query.
+                If all queries are unsuccessful, the traditional queries and
+                the DoH queries will each be made $MaxTries times. Default 2.
+        '''
+        # First attempt the query over traditional DNS
+        result = self.traditional_query(qname, max_tries)
+        success = result['success']
+        trad_empty = result['trad_empty']
+        answers = result['answers']
+        log_entries = result['log_entries']
+
+        if not success:
+            # The traditional DNS query(ies) failed. Retry with DoH
+            result = self.doh_query(qname, max_tries)
+            success = result['success']
+            answers.extend(result['answers'])
+            log_entries.extend(result['log_entries'])
+
+        # There are three possible outcomes of this function:
+        # - Full confidence: we know conclusively that the domain exists or not, either via a
+        # non-empty answer from traditional DNS or an answer from DoH.
+        # - Medium confidence: domain likely doesn't exist, but there is some doubt (empty answer
+        # from traditonal DNS and DoH failed).
+        # No confidence: all queries failed. Throw an exception in this case.
+        if success:
+            return {"Answers": answers, "HighConfidence": True, "LogEntries": log_entries}
+        if trad_empty:
+            return {"Answers": answers, "HighConfidence": False, "LogEntries": log_entries}
+        log = '\n'.join([json.dumps(entry) for entry in log_entries])
+        raise Exception(f"Failed to resolve {qname}. \n{log}")
+
+    def traditional_query(self, qname : str, max_tries : int) -> dict:
+        '''
+        Requests the TXT record for the given qname over DoH.
+
+            :param qname: The query name (ie domain name).
+            :param max_tries: The number of times to retry the query.
+        '''
+        try_number = 0
+        answers = []
+        log_entries = []
+        success = False
+        trad_empty = False
+
+        while try_number < max_tries:
+            try_number += 1
+            try:
+                # No exception was thrown, we got our answer, so break out of the retry loop and set
+                # success to True, no need to retry the traditional query or retry with DoH.
+                response = dns.resolver.resolve(qname, "TXT")
+                for answer in response:
+                    answers.append(answer.to_text().strip('"')) # Strip
+                    # the quotes because the actual response comes wrapped in
+                    # quotes, resulting in duplicate quotes in the json output
+                success = True
+                log_entries.append({
+                    "query_name": qname,
+                    "query_method": "traditional",
+                    "query_result": f"Query returned {len(response)} txt records"})
+                break
+            except dns.resolver.NoAnswer:
+                # The answer section was empty. This usually means that while the domain exists, but
+                # there are no records of the requested type. No need to retry the traditional
+                # query, this was not a transient failure. Don't set success to True though, as we
+                # want to retry this query from a public resolver, in case the internal DNS server
+                # returns a different answer than what is served to the public (i.e., split horizon
+                # DNS).
+                trad_empty = True
+                log_entries.append({
+                    "query_name": qname,
+                    "query_method": "traditional",
+                    "query_result": "Query returned 0 txt records"})
+                break
+            except dns.resolver.NXDOMAIN:
+                # The server returned NXDomain, no need to retry the traditional query or retry with
+                # DoH, this was not a transient failure. Break out of loop and set success to True
+                success = True
+                log_entries.append({
+                    "query_name": qname,
+                    "query_method": "traditional",
+                    "query_result": "Query returned NXDOMAIN"})
+                break
+            except Exception as exception:
+                # The query failed, possibly a transient failure. Retry if we haven't reached max_tries.
+                log_entries.append({
+                    "query_name": qname,
+                    "query_method": "traditional",
+                    "query_result": f"Query resulted in exception {exception}"})
+
+        return {
+            "success": success,
+            "trad_empty": trad_empty,
+            "answers": answers,
+            "log_entries": log_entries
+        }
+
+    def get_doh_server(self) -> str:
+        """Iterates through several DoH servers. Returns the first successful server.
+        If none are successful, returns None.
+        """
+        doh_servers = ["cloudflare-dns.com", "[2606:4700:4700::1111]", "1.1.1.1"]
+        preferred_server = None
+        for server in doh_servers:
+            try:
+                # Attempt to resolve a.root-servers.net over DoH. The domain chosen is somewhat
+                # arbitrary, as we don't care what the answer is, only if the query succeeds/fails.
+                # a.root-servers.net, the address of one of the DNS root servers, was chosen as a
+                # benign, highly-available domain.
+                uri = f"https://{server}/dns-query?name=a.root-servers.net"
+                headers = {"accept":"application/dns-json"}
+                requests.get(uri, headers=headers, timeout=2).json()
+                # No error was thrown, return this server
+                preferred_server = server
+                break
+            except Exception: # pylint: disable=broad-except
+                # This server didn't work, try the next one
+                continue
+        return preferred_server
+
+    def doh_query(self, qname : str, max_tries : int) -> dict:
+        '''
+        Requests the TXT record for the given qname over DoH.
+
+        :param qname: The query name (ie domain name).
+        :param max_tries: The number of times to retry the query.
+        '''
+        log_entries = []
+        try_number = 0
+        answers = []
+        success = False
+
+        if self.doh_server == "":
+            self.doh_server = self.get_doh_server()
+        if self.doh_server is None:
+            # None of the DoH servers are accessible
+            log_entries.append({
+                "query_name": qname,
+                "query_method": "DoH",
+                "query_result": "NA, DoH servers unreachable"
+            })
+        else:
+            # DoH is available, query for the domain
+            while try_number < max_tries:
+                try_number += 1
+                uri = f"https://{self.doh_server}/dns-query?name={qname}&type=txt"
+                headers = {"accept":"application/dns-json"}
+                try:
+                    response = requests.get(uri, headers=headers, timeout=5).json()
+                    if response['Status'] == 0:
+                        # 0 indicates there was no error
+                        log_entries.append({
+                            "query_name": qname,
+                            "query_method": "DoH",
+                            "query_result": f"Query returned {len(response['Answer'])} txt records"})
+                        for answer in response['Answer']:
+                            answers.append(answer['data'].replace('"', ''))
+                        success = True
+                        break
+                    if response['Status'] == 3:
+                        # 3 indicates NXDomain. The DNS query succeeded, but the domain did not exist.
+                        # Set success to True, because event though the domain does not exist, the
+                        # query succeeded, and this came from an external resolver so split horizon is
+                        # not an issue here.
+                        log_entries.append({
+                            "query_name": qname,
+                            "query_method": "DoH",
+                            "query_result": "Query returned NXDomain"})
+                        success = True
+                        break
+                    # The remainder of the response codes indicate that the query did not succeed.
+                    # Retry if we haven't reached max_tries.
+                    log_entries.append({
+                        "query_name": qname,
+                        "query_method": "DoH",
+                        "query_result": f"Query returned response code {response['Status']}"})
+                except Exception as exception:
+                    # The DoH query failed, likely due to a network issue. Retry if we haven't reached
+                    # $MaxTries.
+                    log_entries.append({
+                        "query_name": qname,
+                        "query_method": "DoH",
+                        "query_result": f"Query resulted in exception {exception}"})
+        return {"success": success, "answers": answers, "log_entries": log_entries}

--- a/scubagoggles/robust_dns.py
+++ b/scubagoggles/robust_dns.py
@@ -68,8 +68,8 @@ class RobustDNSClient:
         while try_number < max_tries:
             try_number += 1
             try:
-                # No exception was thrown, we got our answer, so break out of the retry loop and set
-                # success to True, no need to retry the traditional query or retry with DoH.
+                # No exception was thrown, we got our answer, so break out of the retry loop and
+                # set success to True, no need to retry the traditional query or retry with DoH.
                 response = dns.resolver.resolve(qname, "TXT")
                 for answer in response:
                     answers.append(answer.to_text().strip('"')) # Strip
@@ -82,8 +82,8 @@ class RobustDNSClient:
                     "query_result": f"Query returned {len(response)} txt records"})
                 break
             except dns.resolver.NoAnswer:
-                # The answer section was empty. This usually means that while the domain exists, but
-                # there are no records of the requested type. No need to retry the traditional
+                # The answer section was empty. This usually means that while the domain exists,
+                # but there are no records of the requested type. No need to retry the traditional
                 # query, this was not a transient failure. Don't set success to True though, as we
                 # want to retry this query from a public resolver, in case the internal DNS server
                 # returns a different answer than what is served to the public (i.e., split horizon
@@ -95,8 +95,9 @@ class RobustDNSClient:
                     "query_result": "Query returned 0 txt records"})
                 break
             except dns.resolver.NXDOMAIN:
-                # The server returned NXDomain, no need to retry the traditional query or retry with
-                # DoH, this was not a transient failure. Break out of loop and set success to True
+                # The server returned NXDomain, no need to retry the traditional query or retry
+                # with DoH, this was not a transient failure. Break out of loop and set success to
+                # True
                 success = True
                 log_entries.append({
                     "query_name": qname,
@@ -104,7 +105,8 @@ class RobustDNSClient:
                     "query_result": "Query returned NXDOMAIN"})
                 break
             except Exception as exception:
-                # The query failed, possibly a transient failure. Retry if we haven't reached max_tries.
+                # The query failed, possibly a transient failure. Retry if we haven't reached
+                # max_tries.
                 log_entries.append({
                     "query_name": qname,
                     "query_method": "traditional",
@@ -171,19 +173,20 @@ class RobustDNSClient:
                     response = requests.get(uri, headers=headers, timeout=5).json()
                     if response['Status'] == 0:
                         # 0 indicates there was no error
+                        nanswers = len(response['Answer'])
                         log_entries.append({
                             "query_name": qname,
                             "query_method": "DoH",
-                            "query_result": f"Query returned {len(response['Answer'])} txt records"})
+                            "query_result": f"Query returned {nanswers} txt records"})
                         for answer in response['Answer']:
                             answers.append(answer['data'].replace('"', ''))
                         success = True
                         break
                     if response['Status'] == 3:
-                        # 3 indicates NXDomain. The DNS query succeeded, but the domain did not exist.
-                        # Set success to True, because event though the domain does not exist, the
-                        # query succeeded, and this came from an external resolver so split horizon is
-                        # not an issue here.
+                        # 3 indicates NXDomain. The DNS query succeeded, but the domain did not
+                        # exist. Set success to True, because event though the domain does not
+                        # exist, the query succeeded, and this came from an external resolver so
+                        # split horizon is not an issue here.
                         log_entries.append({
                             "query_name": qname,
                             "query_method": "DoH",
@@ -197,8 +200,8 @@ class RobustDNSClient:
                         "query_method": "DoH",
                         "query_result": f"Query returned response code {response['Status']}"})
                 except Exception as exception:
-                    # The DoH query failed, likely due to a network issue. Retry if we haven't reached
-                    # $MaxTries.
+                    # The DoH query failed, likely due to a network issue. Retry if we haven't
+                    # reached max_trues.
                     log_entries.append({
                         "query_name": qname,
                         "query_method": "DoH",


### PR DESCRIPTION
## 🗣 Description ##
- Remove the hard-dependency on IPv4 for the DoH call
- Adjust the DoH logic so that DoH calls are not made when DoH is blocked
- Adjust DNS query logic so that a retry over DoH is not triggered by NXDOMAIN.
- Refactor DNS code into its own class
- Correct a few stray bugs in the DoH request

### 💭 Motivation and context
Closes #120.
Closes #119.

## 🧪 Testing
- Tested normal execution and asserted that the report was correct
- Hard-coded an exception to the regular DNS call to force DoH queries
- Tested on a VM with IPv6 connectivity (let me know if you want me to give you access)

## ✅ Pre-approval checklist ##
- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [x] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [x] Delete the branch to clean up.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
