### PR TITLE
Add support for auth by service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ When running ScubaGoggles for the first time you will be prompted to consent to 
 
 ### Authentication
 
-ScubaGoggles supports both OAuth and Service Accounts for authentication.
+ScubaGoggles supports both OAuth and Service Accounts for authorization/authentication.
 OAuth requires regular user consent while using a service account allows for more automation.
 Follow the instructions below for the authentication method of your choice.
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ If you've limited application access to Google's APIs in your organization, the 
 1. From the hamburger menu, select **IAM & Admin** -> **Service Accounts**
 1. Double click on the newly created service account then click **KEYS** -> **ADD KEY** -> **Create new key** -> **JSON** -> **CREATE**
 1. Move the downloaded file (begins with `<service account>*.json`) to the root directory folder of this repo, rename to `credentials.json`
-1. Now login to admin.google.com and navigate to **Security** -> **Access and data control** -> **API controls**
+1. Now login to [admin.google.com](https://admin.google.com/) and navigate to **Security** -> **Access and data control** -> **API controls**
 1. Select **MANAGE DOMAIN WIDE DELEGATION**
 1. Select **Add new**
 1. Enter the `client_id` from the downloaded credentials (also visible after double clicking on the created Service account under Details -> Unique ID)

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ If you've limited application access to Google's APIs in your organization, the 
 1. Select **AUTHORIZE**
 1. Finally, run ScubaGoggles with the `--subjectemail` option set to the email of an admin with necessary permissions to run ScubaGoggles.
 
-[!NOTE] ScubaGoggles can be run using a service account in a different organization. To do so, specify the `--customerid` argument with the customer ID of the target organization (found in admin.google.com under **Account** -> **Account settings**) 
+> [!NOTE] 
+> ScubaGoggles can be run using a service account in a different organization. 
+> To do so, specify the `--customerid` argument with the customer ID of the target organization (found in admin.google.com under **Account** -> **Account settings**) 
 
 ## Usage
 Execute the ScubaGoggles tool using the `scubagoggles` command. For GWS, all commands will be under the `gws` subparser.

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The tool uses the following OAUTH API scopes.
 When running ScubaGoggles for the first time you will be prompted to consent to these API scopes. Users with the Super Admin role automatically have the privilege to consent to these scopes. A custom admin role can also be made with the minimum permissions to consent to these scopes. See this [Google Admin SDK Prerequisites guide](https://developers.google.com/admin-sdk/reports/v1/guides/prerequisites) for more information.
 
 ### Create a project
-1. If you already have a Google Cloud Project that you want to utilize skip to [Create an OAuth credential](#create-an-oauth-credential)
+1. If you already have a Google Cloud Project that you want to utilize skip to [Authentication](#authentication)
 2. Otherwise start by signing into http://console.cloud.google.com/.
 3. Follow the [directions outlined in this guide to create a project](https://developers.google.com/workspace/guides/create-project)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For the Microsoft 365 (M365) rendition of this tool, see [ScubaGear](https://git
   - [Create a Project](#create-a-project)
   - [Create an OAuth credential](#create-an-oauth-credential)
   - [Add the Oauth App to the allowlist](#add-the-oauth-app-to-the-allowlist)
+  - [Using a service account](#using-a-service-account)
 - [Usage](#usage)
   - [Examples](#example-1-run-an-assessment-against-all-gws-products)
 - [Organization](#organization)
@@ -201,24 +202,45 @@ If you've limited application access to Google's APIs in your organization, the 
 5. Select your root organization as the domain
 6. Select **Trusted**
 
+### Using a Service Account
+
+1. In GCP navigate to **IAM & Admin** -> **Service Accounts**
+1. Select **CREATE SERVICE ACCOUNT**. Fill out the id field and then select **DONE**
+1. Click on the new service account then **KEYS** -> **ADD KEY** -> **Create new key** -> **JSON** -> **CREATE**
+1. Move the downloaded file (begins with `<service account>*.json`) to the root directory folder of this repo, rename to `credentials.json`
+1. In GWS navigate to **Security** -> **Access and data control** -> **API controls**
+1. Select **MANAGE DOMAIN WIDE DELEGATION**
+1. Select **Add new**
+1. Enter the client id from the downloaded credentials (also available in GCP)
+1. Enter each OAuth scope as listed in [OAuth API Scopes](#oauth-api-scopes)
+1. Select **AUTHORIZE**
+1. Finally run ScubaGoggles with the `--customer` option set to the customer ID (found in GWS under **Account** -> **Account settings**) 
+and the `--subjectemail` option set to the email of an admin with necessary permissions to run ScubaGoggles.
+
 ## Usage
 Execute the ScubaGoggles tool using the `scubagoggles` command. For GWS, all commands will be under the `gws` subparser.
 
 ```
 scubagoggles gws -h
-usage: scubagoggles gws [-h] [-b  [...]] [-o] [-c] [--opapath] [--regopath] [--documentpath] [--runcached]
-                        [--skipexport] [--outputfoldername] [--outputproviderfilename] [--outputregofilename]
-                        [--outputreportfilename] [--debug]
+usage: scuba.py gws [-h] [-b  [...]] [-o] [-c] [--subjectemail] [--customer] [--opapath] [--regopath] [--documentpath]
+                    [--runcached] [--skipexport] [--outputfoldername] [--outputproviderfilename]
+                    [--outputregofilename] [--outputreportfilename] [--omitsudo] [--quiet] [--debug]
 
-options:
+optional arguments:
   -h, --help            show this help message and exit
   -b  [ ...], --baselines  [ ...]
-                        A list of one or more abbreviated GWS baseline names that the tool will assess. Defaults to all
-                        baselines. Choices: gmail, calendar, groups, chat, drive, meet, sites, commoncontrols, rules
+                        A list of one or more abbreviated GWS baseline names that the tool will assess. Defaults to
+                        all baselines. Choices: gmail, calendar, groups, chat, drive, meet, sites, commoncontrols,
+                        rules, classroom
   -o , --outputpath     The folder path where both the output JSON & HTML report will be created. Defaults to "./" The
                         current directory.
-  -c , --credentials    The relative path and name of the OAuth credentials json file. Defaults to "./credentials.json"
-                        which means the tool will look for the file named credentials.json in the current directory.
+  -c , --credentials    The relative path and name of the OAuth / service account credentials json file. Defaults to
+                        "./credentials.json" which means the tool will look for the file named credentials.json in the
+                        current directory.
+  --subjectemail        Only applicable when using a service account. The email address of a user the service account
+                        should act on behalf of. This user must have the necessary privileges to run scubagoggles.
+  --customer            The customer ID the tool should run on. Defaults to "my_customer" which will be the user's
+                        domain when using OAuth
   --opapath             The relative path to the directory containing the OPA executable. Defaults to "./" the current
                         executing directory.
   --regopath            The relative path to the directory contain the folder containing the rego files. Defaults to
@@ -232,16 +254,16 @@ options:
   --outputfoldername    The name of the folder created in --outputpath where both the output JSON and the HTML report
                         will be created. Defaults to GWSBaselineConformance. The client's local timestamp will be
                         appended to this name.
-  --outputproviderfilename
+  --outputproviderfilename 
                         The name of the Provider output json in --outputpath. Defaults to ProviderSettingsExport.
-  --outputregofilename
+  --outputregofilename 
                         The name of the Rego output json in --outputpath. Defaults to TestResults.
-  --outputreportfilename
+  --outputreportfilename 
                         The name of the main html file homepage created in --outputpath. Defaults to BaselineReports.
   --omitsudo            This switch prevents running the OPA executable with sudo.
-  --quiet               This switch suppresses automatically launching a web browser to open the html report output and
-                        the loading bar output.
-  --debug               This switch is used to print debugging information for OPA
+  --quiet               This switch suppresses automatically launching a web browser to open the html report output
+                        and the loading bar output.
+  --debug               This switch is used to print debugging information for OPA.
 ```
 
 ### Example 1: Run an assessment against all GWS products
@@ -265,6 +287,11 @@ scubagoggles gws -b calendar gmail groups chat meet sites -o ./output
 # used for running against a cached provider json
 
 scubagoggles gws --runcached --skipexport
+```
+
+### Example 5: Run with a service account
+```
+scubagoggles gws --customer <customer_id> --subjectemail admin@example.com
 ```
 
 See the `help` options yourself

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ scubagoggles gws --runcached --skipexport
 
 ### Example 5: Run with a service account on a different tenant
 ```
-scubagoggles gws --customer <customer_id> --subjectemail admin@example.com
+scubagoggles gws --customerid <customer_id> --subjectemail admin@example.com
 ```
 
 See the `help` options yourself

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Execute the ScubaGoggles tool using the `scubagoggles` command. For GWS, all com
 
 ```
 scubagoggles gws -h
-usage: scubagoggles gws [-h] [-b  [...]] [-o] [-c] [--subjectemail] [--customer] [--opapath] [--regopath] [--documentpath]
+usage: scubagoggles gws [-h] [-b  [...]] [-o] [-c] [--subjectemail] [--customerid] [--opapath] [--regopath] [--documentpath]
                     [--runcached] [--skipexport] [--outputfoldername] [--outputproviderfilename]
                     [--outputregofilename] [--outputreportfilename] [--omitsudo] [--quiet] [--debug]
 

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ If you've limited application access to Google's APIs in your organization, the 
 
 > [!NOTE] 
 > ScubaGoggles can be run using a service account in a different organization. 
-> To do so, specify the `--customerid` argument with the customer ID of the target organization (found in admin.google.com under **Account** -> **Account settings**) 
+> To do so, specify the `--customerid` argument with the customer ID of the target organization (found in [admin.google.com](https://admin.google.com/) under **Account** -> **Account settings**) 
 
 ## Usage
 Execute the ScubaGoggles tool using the `scubagoggles` command. For GWS, all commands will be under the `gws` subparser.

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ If you've limited application access to Google's APIs in your organization, the 
 1. Select **API's & Services** from the top left hamburger icon
 1. Select **Credentials**
 1. Copy your client ID under **OAuth 2.0 Client IDs**
-1. Now login to admin.google.com and navigate to **Security** -> **Access and Data Control** -> **API Controls** -> **Manage Third-Party App Access**
+1. Now login to [admin.google.com](https://admin.google.com/) and navigate to **Security** -> **Access and Data Control** -> **API Controls** -> **Manage Third-Party App Access**
 1. Select **Add App** -> **Oauth App Name** or **Client ID**
 1. Search by your **OAuth client ID**
 1. Select the App

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -26,17 +26,19 @@ def gws_auth(cred_path:str, subject_email: str = None):
     Generates an Oauth token for accessing Google's APIs
 
     :param cred_path: directory containing the credentials file
-    :param subject_email: if set, assumes credentials are for service account and uses this email as the subject
+    :param subject_email: if set, assumes credentials are for service account and uses
+        this email as the subject
     """
     cred_dir = Path(cred_path).parent
     creds = None
-    
+
     if subject_email is not None:
-        creds = SvcCredentials.from_service_account_file(cred_path, scopes=SCOPES, subject=subject_email)
+        creds = SvcCredentials.from_service_account_file(cred_path, scopes=SCOPES,
+                                                         subject=subject_email)
         if not creds.valid:
             creds.refresh(Request())
         return creds
-    
+
     oauth_token = (cred_dir / 'token.json').resolve()
     if os.path.exists(oauth_token):
         creds = Credentials.from_authorized_user_file(oauth_token, SCOPES)

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -21,7 +21,7 @@ SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly',
     "https://www.googleapis.com/auth/apps.groups.settings"]
 
 
-def gws_auth(cred_path:str, subject_email: str):
+def gws_auth(cred_path:str, subject_email: str = None):
     """
     Generates an Oauth token for accessing Google's APIs
 

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -9,6 +9,7 @@ import os.path
 from pathlib import Path
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
+from google.oauth2.service_account import Credentials as SvcCredentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 # If modifying these scopes, delete the file token.json.
@@ -20,16 +21,23 @@ SCOPES = ['https://www.googleapis.com/auth/admin.reports.audit.readonly',
     "https://www.googleapis.com/auth/apps.groups.settings"]
 
 
-def gws_auth(cred_path:str):
+def gws_auth(cred_path:str, subject_email: str):
     """
     Generates an Oauth token for accessing Google's APIs
 
     :param cred_path: directory containing the credentials file
+    :param subject_email: if set, assumes credentials are for service account and uses this email as the subject
     """
     cred_dir = Path(cred_path).parent
-    oauth_token = (cred_dir / 'token.json').resolve()
-
     creds = None
+    
+    if subject_email is not None:
+        creds = SvcCredentials.from_service_account_file(cred_path, scopes=SCOPES, subject=subject_email)
+        if not creds.valid:
+            creds.refresh(Request())
+        return creds
+    
+    oauth_token = (cred_dir / 'token.json').resolve()
     if os.path.exists(oauth_token):
         creds = Credentials.from_authorized_user_file(oauth_token, SCOPES)
     # If there are no (valid) credentials available, let the user log in.

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -43,9 +43,9 @@ def get_gws_args(parser):
     'The email address of a user the service account should act on behalf of. ' +
     'This user must have the necessary privileges to run scubagoggles.')
 
-    parser.add_argument("--customer", type=str, default="my_customer", metavar='',
+    parser.add_argument("--customerid", type=str, default="my_customer", metavar='',
     help='The customer ID the tool should run on. Defaults to "my_customer" which will be' +
-    ' the user\'s domain when using OAuth')
+    ' the domain of the user / service account authenticating.')
 
     parser.add_argument('--opapath', type=str, default='./', metavar='',
     help='The relative path to the directory containing the OPA executable. ' +

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -34,9 +34,18 @@ def get_gws_args(parser):
     ' Defaults to "./" The current directory. ')
 
     parser.add_argument('-c','--credentials', type=str,default='./credentials.json', metavar='',
-    help='The relative path and name of the OAuth credentials json file. ' +
+    help='The relative path and name of the OAuth / service account credentials json file. ' +
     'Defaults to "./credentials.json" which means the tool will look ' +
     'for the file named credentials.json in the current directory.')
+
+    parser.add_argument('--subjectemail', type=str, default=None, metavar='',
+    help='Only applicable when using a service account. ' +
+    'The email address of a user the service account should act on behalf of. ' +
+    'This user must have the necessary privileges to run scubagoggles.')
+
+    parser.add_argument("--customer", type=str, default="my_customer", metavar='',
+    help='The customer ID the tool should run on. Defaults to "my_customer" which will be' +
+    ' the user\'s domain when using OAuth')
 
     parser.add_argument('--opapath', type=str, default='./', metavar='',
     help='The relative path to the directory containing the OPA executable. ' +

--- a/scubagoggles/orchestrator.py
+++ b/scubagoggles/orchestrator.py
@@ -63,7 +63,7 @@ def run_gws_providers(args, services):
     out_folder = args.outputpath
     provider_dict = {}
 
-    provider_dict = call_gws_providers(products, services, args.quiet, args.customer)
+    provider_dict = call_gws_providers(products, services, args.quiet, args.customerid)
 
     settings_json = json.dumps(provider_dict, indent = 4)
     out_path = out_folder + f'/{args.outputproviderfilename}.json'

--- a/scubagoggles/orchestrator.py
+++ b/scubagoggles/orchestrator.py
@@ -63,7 +63,7 @@ def run_gws_providers(args, services):
     out_folder = args.outputpath
     provider_dict = {}
 
-    provider_dict = call_gws_providers(products, services, args.quiet)
+    provider_dict = call_gws_providers(products, services, args.quiet, args.customer)
 
     settings_json = json.dumps(provider_dict, indent = 4)
     out_path = out_folder + f'/{args.outputproviderfilename}.json'
@@ -310,7 +310,7 @@ def start_automation(args):
         args.outputpath = os.path.abspath(args.outputpath)
 
         # authenticate
-        creds = gws_auth(args.credentials)
+        creds = gws_auth(args.credentials, args.subjectemail)
         services = {}
         services['reports'] = build('admin', 'reports_v1', credentials=creds)
         services['directory'] = build('admin', 'directory_v1', credentials=creds)


### PR DESCRIPTION
## 🗣 Description ##

Adds support for authenticating using a service account and domain-wide delegation

### 💭 Motivation and context

Authenticating through a service account allows the tool to be used in automated scenarios where user consent is not possible.

Closes #82 


## 🧪 Testing

Testing has been done manually by following the new instructions in the README

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
