### PR TITLE
md_parser: change test for end of policy text in read_baseline_docs() (issue 202)

### DIFF
--- a/scubagoggles/reporter/md_parser.py
+++ b/scubagoggles/reporter/md_parser.py
@@ -68,7 +68,9 @@ def read_baseline_docs(baseline_path:str, prod_to_fullname:dict):
                 line_advance = 1
                 value = md_lines[line_number + line_advance].strip()
 
-                while not value.endswith("."):
+                # We're done getting the policy text as soon as we encounter
+                # a blank line.
+                while md_lines[line_number + line_advance + 1].strip():
                     line_advance += 1
                     value += " " + md_lines[line_number + line_advance].strip()
 


### PR DESCRIPTION
## 🗣 Description ##

Changed the parsing of the baseline markdown (MD) files to extract the policy requirement text for the report.

### 💭 Motivation and context

The issue identifies 2 policies in the Google Calendar report (1.2 & 1.2) where the requirement text in the report also includes the rationale, which should not be included.  Currently, when the markdown is parsed for the requirement text, a period (.) is used to determine the end of the requirement.  For the two requirements that incorrectly include the rationale in the report, the requirement text ends with a quoted string, where the ending period is inside the quotes (e.g., External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details).").  Those statements are actually grammatically correct (to my knowledge 😄) - ending punctuation is included in the quoted string.

After looking at the markdown files, I noticed that every requirement is followed by a blank line before the rationale.  An easier way to resolve this issue is to change the parsing slightly to look for a blank line instead of a period as the end delimiter for the requirement text.  This corrects the two calendar policies mentioned in this issue, as well as a common controls policy (8.1) that has a missing period at the end of the requirement text (which could be fixed, but this change will still prevent the rationale from incorrectly being included in with the requirement in the meantime).

Closes #202

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

### Current requirement text: ###

Calendar 1.1:

> External Sharing Options for Primary Calendars SHALL be configured to "Only free/busy information (hide event details)." - Rationale - Prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.

Calendar 1.2:

> External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details)." - Rationale - Prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.

Common Controls 8.1:

> Account self-recovery for Super Admins SHALL be disabled - Rationale - This forces Super Admin users who have lost their login credentials to contact another Super Admin to recover their account. This makes it more difficult for a potential adversary from being able to attempt to gain access to a super admin account through the method of account recovery.

### Requirement text AFTER MD parser change; ###

Calendar 1.1:

> External Sharing Options for Primary Calendars SHALL be configured to "Only free/busy information (hide event details)."

Calendar 1.2:

> External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details)."

Common Controls 8.1:

> Account self-recovery for Super Admins SHALL be disabled

### Other requirement text ###

For all other requirements, the requirement text remains the same after the parser change.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [x] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [x] Delete the branch to clean up.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
