### PR TITLE
Categorize rules as "manual checks" if no events found (issue 185)

### DIFF
--- a/scubagoggles/reporter/reporter.py
+++ b/scubagoggles/reporter/reporter.py
@@ -23,17 +23,24 @@ def get_test_result(requirement_met : bool, criticality : str, no_such_events : 
         values: should, may, 3rd Party, Not-Implemented
     :param no_such_events: boolean whether there are no such events
     '''
+
+    # If there were no log events for the test, the state of "requirement_met"
+    # doesn't matter - it's a test requiring a manual check (i.e., "no events
+    # found").
+
     criticality = criticality.lower()
-    if requirement_met:
-        result = "Pass"
-    elif "3rd party" in criticality or 'not-implemented' in criticality:
-        result = "N/A"
+
+    if '3rd party' in criticality or 'not-implemented' in criticality:
+        result = 'N/A'
     elif no_such_events:
-        result = "No events found"
+        result = 'No events found'
+    elif requirement_met:
+        result = 'Pass'
     elif criticality in ('should', 'may'):
-        result = "Warning"
+        result = 'Warning'
     else:
-        result = "Fail"
+        result = 'Fail'
+
     return result
 
 def create_html_table(table_data : list) -> str:


### PR DESCRIPTION
## 🗣 Description ##

This is Alden's suggested implementation.  With the previous behavior, tests were being categorized as passing even if no events were found in the logs.

### 💭 Motivation and context

This change correctly categorizes tests that should be manual checks because no log events were found to determine the test result.

Closes #185

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

This change was tested in the "scubagws" environment, and only affects the Rules baseline.  The summary counts for the Rules baseline before the change:

|Baseline|Passed|Manual|
|-----|-----|-----|
|Rules|22 tests passed|18 manual checks needed|

These are the counts after the change:

|Baseline|Passed|Manual|
|-----|-----|-----|
|Rules|1 test passed|39 manual checks needed|

This is correct because 21 tests were marked as both "no events found" and "requirement met".  With the new change, the 21 tests have moved from "passed" to "manual."

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [x] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
