### PR TITLE
Refactor Rationales for Calendar, Classroom, and Sites

### DIFF
--- a/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
@@ -92,8 +92,8 @@ This section determines whether users are warned when inviting one or more guest
 #### GWS.CALENDAR.2.1v0.1
 External invitations warnings SHALL be enabled to prompt users before sending invitations.
 
-- *Rationale:* Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help mitigate this risk.
-- _Last Modified:_ July 10, 2023
+- _Rationale:_ Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help mitigate this risk.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -135,7 +135,7 @@ Due to the added complexity and attack surface associated with configuring Calen
 Calendar Interop SHOULD be disabled.
 
 - _Rationale:_ Enabling Calendar interop adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature unless required by the organization conforms to the principle of least functionality.
-- _Last Modified:_ July 10, 2023
+- _Last modified:_ July 10, 2023
 - Notes
   - This policy applies unless agency mission fulfillment requires collaboration between users internal and external to an organization who use both Microsoft Exchange and Google Calendar
 

--- a/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
@@ -38,9 +38,8 @@ This section determines what information is shared from calendars with external 
 #### GWS.CALENDAR.1.1v0.1
 External Sharing Options for Primary Calendars SHALL be configured to "Only free/busy information (hide event details)."
 
-- Rationale
-  - Prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
-- Last Modified: July 10, 2023
+- *Rationale:* Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -48,9 +47,8 @@ External Sharing Options for Primary Calendars SHALL be configured to "Only free
 #### GWS.CALENDAR.1.2v0.1
 External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details)."
 
-- Rationale
-  - Prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
-- Last Modified: July 10, 2023
+- *Rationale*: Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -94,9 +92,8 @@ This section determines whether users are warned when inviting one or more guest
 #### GWS.CALENDAR.2.1v0.1
 External invitations warnings SHALL be enabled to prompt users before sending invitations.
 
-- Rationale
-  - When your users create a Google Calendar event that includes one or more guests from outside of your domain, they are prompted to confirm whether it's OK to include external guests in the event invitation, assisting in the prevention of unintentional data leakage.
-- Last Modified: July 10, 2023
+- *Rationale:* Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help mitigate this risk.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -137,9 +134,8 @@ Due to the added complexity and attack surface associated with configuring Calen
 #### GWS.CALENDAR.3.1v0.1
 Calendar Interop SHOULD be disabled.
 
-- Rationale
-  - Minimize attack surface by not enabling this feature which relies on Exchange Web Services for information exchange between Microsoft and Google calendars, unless required by the organization.
-- Last Modified: July 10, 2023
+- *Rationale:* Enabling Calendar interop adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature unless required by the organization conforms to the principle of least functionality.
+- *Last Modified:* July 10, 2023
 - Notes
   - This policy applies unless agency mission fulfillment requires collaboration between users internal and external to an organization who use both Microsoft Exchange and Google Calendar
 
@@ -150,9 +146,8 @@ Calendar Interop SHOULD be disabled.
 #### GWS.CALENDAR.3.2v0.1
 OAuth 2.0 SHALL be used in lieu of basic authentication to establish connectivity between tenants or organizations in cases where Calendar Interop is deemed necessary for agency mission fulfillment.
 
-- Rationale
-  - When required by organizational requirements, for user's to exchange information between Google and Microsoft calendars, users will be authenticated using OAuth 2.0 to prevent unauthorized access.
-- Last Modified: July 10, 2023
+- *Rationale:* Basic authentication is a deprecated and risk-prone authentication method. Using OAuth 2.0 helps reduce the risk of credential compromise.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1555: Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)
@@ -160,6 +155,7 @@ OAuth 2.0 SHALL be used in lieu of basic authentication to establish connectivit
 ### Resources
 
 -   [Google Workspace Admin Help: About Calendar Interop](https://support.google.com/a/answer/7444958?hl=en)
+-   [Deprecation of Basic Authentication in Exchange Online](https://learn.microsoft.com/en-us/exchange/clients-and-mobile-in-exchange-online/deprecation-of-basic-authentication-exchange-online)
 
 ### Prerequisites
 
@@ -196,10 +192,8 @@ This section covers whether or not the paid appointment booking feature is enabl
 #### GWS.CALENDAR.4.1v0.1
 Appointment Schedule with Payments SHALL be disabled.
 
-- Rationale
-  - This helps avoid unnecessary interconnectivity with third-party services that can create a greater chance of additional vulnerabilities in the platform.
-  - There is no obvious need for agencies to have this feature enabled.
-- Last Modified: July 10, 2023
+- *Rationale:* Enabling paid appointments adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature conforms to the principle of least functionality.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)

--- a/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Calendar Minimum Viable Secure Configuration Baseline v0.1.md
@@ -38,8 +38,8 @@ This section determines what information is shared from calendars with external 
 #### GWS.CALENDAR.1.1v0.1
 External Sharing Options for Primary Calendars SHALL be configured to "Only free/busy information (hide event details)."
 
-- *Rationale:* Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -47,8 +47,8 @@ External Sharing Options for Primary Calendars SHALL be configured to "Only free
 #### GWS.CALENDAR.1.2v0.1
 External sharing options for secondary calendars SHALL be configured to "Only free/busy information (hide event details)."
 
-- *Rationale*: Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Calendars can contain private or otherwise sensitive information. Restricting calendar details to only free/busy information helps prevent data leakage by restricting the amount of information that is externally viewable when a user shares their calendar with someone external to your organization.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -93,7 +93,7 @@ This section determines whether users are warned when inviting one or more guest
 External invitations warnings SHALL be enabled to prompt users before sending invitations.
 
 - *Rationale:* Users may inadvertently include external guests in calendar event invitations, potentially resulting in data leakage. Warning users when external participants are included can help mitigate this risk.
-- *Last Modified:* July 10, 2023
+- _Last Modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -134,8 +134,8 @@ Due to the added complexity and attack surface associated with configuring Calen
 #### GWS.CALENDAR.3.1v0.1
 Calendar Interop SHOULD be disabled.
 
-- *Rationale:* Enabling Calendar interop adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature unless required by the organization conforms to the principle of least functionality.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Enabling Calendar interop adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature unless required by the organization conforms to the principle of least functionality.
+- _Last Modified:_ July 10, 2023
 - Notes
   - This policy applies unless agency mission fulfillment requires collaboration between users internal and external to an organization who use both Microsoft Exchange and Google Calendar
 
@@ -146,8 +146,8 @@ Calendar Interop SHOULD be disabled.
 #### GWS.CALENDAR.3.2v0.1
 OAuth 2.0 SHALL be used in lieu of basic authentication to establish connectivity between tenants or organizations in cases where Calendar Interop is deemed necessary for agency mission fulfillment.
 
-- *Rationale:* Basic authentication is a deprecated and risk-prone authentication method. Using OAuth 2.0 helps reduce the risk of credential compromise.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Basic authentication is a deprecated and risk-prone authentication method. Using OAuth 2.0 helps reduce the risk of credential compromise.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1555: Credentials from Password Stores](https://attack.mitre.org/techniques/T1555/)
@@ -192,8 +192,8 @@ This section covers whether or not the paid appointment booking feature is enabl
 #### GWS.CALENDAR.4.1v0.1
 Appointment Schedule with Payments SHALL be disabled.
 
-- *Rationale:* Enabling paid appointments adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature conforms to the principle of least functionality.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Enabling paid appointments adds a layer of complexity to Calendar management, possibly increasing the attack surface. Disabling this feature conforms to the principle of least functionality.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)

--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -40,9 +40,8 @@ This section covers who has the ability to join classes and what classes the use
 #### GWS.CLASSROOM.1.1v0.1
 Who can join classes in your domain SHALL be set to Users in your domain only.
 
-- Rationale
-  - Allowing users to join from outside your domain creates the potential for an unauthorized data leak.
-- Last Modified: September 27, 2023
+- *Rationale:* Classes can contain private or otherwise sensitive information. Restricting classes to users in your domain helps prevent data leakage resulting from unauthorized classroom access.
+- *Last Modified:* September 27, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -51,9 +50,8 @@ Who can join classes in your domain SHALL be set to Users in your domain only.
 #### GWS.CLASSROOM.1.2v0.1
 Which classes users in your domain can join SHALL be set to Classes in your domain only.
 
-- Rationale
-  - Joining a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
-- Last Modified: September 27, 2023
+- *Rationale:* Joining a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
+- *Last Modified:* September 27, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -92,9 +90,8 @@ This section covers policies related to the Google Classroom API.
 #### GWS.CLASSROOM.2.1v0.1
 Users SHALL NOT be able to authorize apps to access their Google Classroom data.
 
-- Rationale
-  - Allowing ordinary users to authorize apps to access to classroom data opens a possibility for data loss. Only admins should be allowed to authorize apps.
-- Last Modified: September 28, 2023
+- *Rationale:* Allowing ordinary users to authorize apps to access to classroom data opens a possibility for data loss. Only allowing admins to authorize apps reduces this risk.
+- *Last Modified:* September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
@@ -128,16 +125,11 @@ This section covers policies related to importing rosters from Clever.
 #### GWS.CLASSROOM.3.1v0.1
 Roster import with Clever SHOULD be turned off.
 
-- Rationale
-  - If your organization does not use Clever, allowing roster import could create a way to for data to be inputted into the organization's environment which allows from unauthorized data in the system. In addition, it could allow for unauthorized data leak as well.
-- Last Modified: September 28, 2023
-- Note:
-  - Only to be set to on if your organization uses Clever
+- *Rationale:* If your organization does not use Clever, allowing roster import could create a way to for data to be inputted into the organization's environment which allows from unauthorized data in the system. If your organization does use Clever, then roster import may be enabled.
+- *Last Modified:* September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
-  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
-    - [T1048:002: Exfiltration Over Alternative Protocol: Exfiltration Over Asymmetric Encrypted Non-C2 Protocol](https://attack.mitre.org/techniques/T1048/002/)
 
 ### Resources
 
@@ -166,8 +158,7 @@ This section covers policies related to unenrolling a student from a class.
 #### GWS.CLASSROOM.4.1v0.1
 Only teachers SHALL be allowed to unenroll students from classes.
 
-- Rationale
-  - Only allowing teachers to unenroll students helps ensure that there is no potential for unintentional data loss or inconsistency between Google and Clever, if applicable.
+- *Rationale:* Allowing students to unenroll themselves creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
 - Last Modified: September 28, 2023
 
 - MITRE ATT&CK TTP Mapping

--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -125,7 +125,7 @@ This section covers policies related to importing rosters from Clever.
 #### GWS.CLASSROOM.3.1v0.1
 Roster import with Clever SHOULD be turned off.
 
-- _Rationale:_ If your organization does not use Clever, allowing roster import could create a way to for data to be inputted into the organization's environment which allows from unauthorized data in the system. If your organization does use Clever, then roster import may be enabled.
+- _Rationale:_ If your organization does not use Clever, allowing roster imports could create a way for unauthorized data to be inputted into your organization's environment. If your organization does use Clever, then roster imports may be enabled.
 - _Last modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping

--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -50,7 +50,7 @@ Who can join classes in your domain SHALL be set to Users in your domain only.
 #### GWS.CLASSROOM.1.2v0.1
 Which classes users in your domain can join SHALL be set to Classes in your domain only.
 
-- _Rationale:_ Joining a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
+- _Rationale:_ Allowing users to join a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
 - _Last modified:_ September 27, 2023
 
 - MITRE ATT&CK TTP Mapping
@@ -90,7 +90,7 @@ This section covers policies related to the Google Classroom API.
 #### GWS.CLASSROOM.2.1v0.1
 Users SHALL NOT be able to authorize apps to access their Google Classroom data.
 
-- _Rationale:_ Allowing ordinary users to authorize apps to access to classroom data opens a possibility for data loss. Only allowing admins to authorize apps reduces this risk.
+- _Rationale:_ Allowing ordinary users to authorize apps to have access to classroom data opens a possibility for data loss. Allowing only admins to authorize apps reduces this risk.
 - _Last modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
@@ -159,7 +159,7 @@ This section covers policies related to unenrolling a student from a class.
 Only teachers SHALL be allowed to unenroll students from classes.
 
 - _Rationale:_ Allowing students to unenroll themselves creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
-- _Last Modified:_ September 28, 2023
+- _Last modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)

--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -159,7 +159,7 @@ This section covers policies related to unenrolling a student from a class.
 Only teachers SHALL be allowed to unenroll students from classes.
 
 - _Rationale:_ Allowing students to unenroll themselves creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
-- Last Modified: September 28, 2023
+- _Last Modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)

--- a/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Classroom Minimum Viable Secure Configuration Baseline v0.1.md
@@ -40,8 +40,8 @@ This section covers who has the ability to join classes and what classes the use
 #### GWS.CLASSROOM.1.1v0.1
 Who can join classes in your domain SHALL be set to Users in your domain only.
 
-- *Rationale:* Classes can contain private or otherwise sensitive information. Restricting classes to users in your domain helps prevent data leakage resulting from unauthorized classroom access.
-- *Last Modified:* September 27, 2023
+- _Rationale:_ Classes can contain private or otherwise sensitive information. Restricting classes to users in your domain helps prevent data leakage resulting from unauthorized classroom access.
+- _Last modified:_ September 27, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -50,8 +50,8 @@ Who can join classes in your domain SHALL be set to Users in your domain only.
 #### GWS.CLASSROOM.1.2v0.1
 Which classes users in your domain can join SHALL be set to Classes in your domain only.
 
-- *Rationale:* Joining a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
-- *Last Modified:* September 27, 2023
+- _Rationale:_ Joining a class from outside your domain could allow for data to be exfiltrated to entities outside the control of the organization creating a significant security risk.
+- _Last modified:_ September 27, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
@@ -90,8 +90,8 @@ This section covers policies related to the Google Classroom API.
 #### GWS.CLASSROOM.2.1v0.1
 Users SHALL NOT be able to authorize apps to access their Google Classroom data.
 
-- *Rationale:* Allowing ordinary users to authorize apps to access to classroom data opens a possibility for data loss. Only allowing admins to authorize apps reduces this risk.
-- *Last Modified:* September 28, 2023
+- _Rationale:_ Allowing ordinary users to authorize apps to access to classroom data opens a possibility for data loss. Only allowing admins to authorize apps reduces this risk.
+- _Last modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1059: Command and Scripting Interpreter](https://attack.mitre.org/techniques/T1059/)
@@ -125,8 +125,8 @@ This section covers policies related to importing rosters from Clever.
 #### GWS.CLASSROOM.3.1v0.1
 Roster import with Clever SHOULD be turned off.
 
-- *Rationale:* If your organization does not use Clever, allowing roster import could create a way to for data to be inputted into the organization's environment which allows from unauthorized data in the system. If your organization does use Clever, then roster import may be enabled.
-- *Last Modified:* September 28, 2023
+- _Rationale:_ If your organization does not use Clever, allowing roster import could create a way to for data to be inputted into the organization's environment which allows from unauthorized data in the system. If your organization does use Clever, then roster import may be enabled.
+- _Last modified:_ September 28, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1199: Trusted Relationship](https://attack.mitre.org/techniques/T1199/)
@@ -158,7 +158,7 @@ This section covers policies related to unenrolling a student from a class.
 #### GWS.CLASSROOM.4.1v0.1
 Only teachers SHALL be allowed to unenroll students from classes.
 
-- *Rationale:* Allowing students to unenroll themselves creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
+- _Rationale:_ Allowing students to unenroll themselves creates the opportunity for data loss or other inconsistencies, especially for K-12 classrooms. Restricting this ability to teachers mitigates this risk.
 - Last Modified: September 28, 2023
 
 - MITRE ATT&CK TTP Mapping

--- a/baselines/Google Sites Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Sites Minimum Viable Secure Configuration Baseline v0.1.md
@@ -37,8 +37,8 @@ This section covers whether users are able to access Google Sites.
 #### GWS.SITES.1.1v0.1
 Sites Service SHOULD be disabled for all users.
 
-- *Rationale:* Google Sites can increase the attack surface of Google Workspace. Disabling this feature unless it is needed conforms to the principle of least functionality.
-- *Last Modified:* July 10, 2023
+- _Rationale:_ Google Sites can increase the attack surface of Google Workspace. Disabling this feature unless it is needed conforms to the principle of least functionality.
+- _Last modified:_ July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1526: Cloud Service Discovery](https://attack.mitre.org/techniques/T1526/)

--- a/baselines/Google Sites Minimum Viable Secure Configuration Baseline v0.1.md
+++ b/baselines/Google Sites Minimum Viable Secure Configuration Baseline v0.1.md
@@ -37,9 +37,8 @@ This section covers whether users are able to access Google Sites.
 #### GWS.SITES.1.1v0.1
 Sites Service SHOULD be disabled for all users.
 
-- Rationale
-  - This helps to minimize attack surface. Not every user within an organization needs access to Google Sites. If this capability is needed, it can be enabled and configured for those users based on user's assigned organizational unit (OU) and by exception as required by the organization to meet specific needs.
-- Last Modified: July 10, 2023
+- *Rationale:* Google Sites can increase the attack surface of Google Workspace. Disabling this feature unless it is needed conforms to the principle of least functionality.
+- *Last Modified:* July 10, 2023
 
 - MITRE ATT&CK TTP Mapping
   - [T1526: Cloud Service Discovery](https://attack.mitre.org/techniques/T1526/)


### PR DESCRIPTION
## 🗣 Description ##
Refactor the rationales of Calendar, Classroom, and Sites:
- Display the rationale content on the same line as the rationale heading, as done for the M365 baselines
- Modify the rationales to follow the template generally used for the M365 baselines, i.e., "Description of risk. Description of how this baseline mitigates this risk."

### 💭 Motivation and context
- Maintain parity with the M365 baselines
- Create more precise rationales

## 🧪 Testing
N/A

## ✅ Pre-approval checklist ##
- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
