### PR TITLE
Add group-setting support for Sites

### DIFF
--- a/Testing/RegoTests/sites/sites01_test.rego
+++ b/Testing/RegoTests/sites/sites01_test.rego
@@ -31,7 +31,7 @@ test_Sites_Disabled_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Sites_Disabled_Correct_V2 if {
@@ -71,7 +71,7 @@ test_Sites_Disabled_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Sites_Disabled_Correct_V3 if {
@@ -111,7 +111,7 @@ test_Sites_Disabled_Correct_V3 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Sites_Disabled_Correct_V4 if {
@@ -162,10 +162,9 @@ test_Sites_Disabled_Correct_V4 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
-#--------TO FIX
 test_Sites_Disabled_Correct_V5 if {
     # Test Sites inheritance
     PolicyId := "GWS.SITES.1.1v0.1"
@@ -214,7 +213,7 @@ test_Sites_Disabled_Correct_V5 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Sites_Disabled_Incorrect_V1 if {
@@ -254,7 +253,8 @@ test_Sites_Disabled_Incorrect_V1 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails ==
+        "The following OUs are non-compliant:<ul><li>Test Top-Level OU: Service status for Sites is ON.</li></ul>"
 }
 
 test_Sites_Disabled_Incorrect_V2 if {
@@ -283,7 +283,8 @@ test_Sites_Disabled_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails ==
+        "The following OUs are non-compliant:<ul><li>Test Top-Level OU: Service status for Sites is ON.</li></ul>"
 }
 
 test_Sites_Disabled_Incorrect_V3 if {
@@ -323,7 +324,8 @@ test_Sites_Disabled_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails ==
+        "The following OUs are non-compliant:<ul><li>Test Top-Level OU: Service status for Sites is ON.</li></ul>"
 }
 
 test_Sites_Disabled_Incorrect_V4 if {
@@ -363,7 +365,8 @@ test_Sites_Disabled_Incorrect_V4 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Secondary OU."
+    RuleOutput[0].ReportDetails ==
+        "The following OUs are non-compliant:<ul><li>Secondary OU: Service status for Sites is ON.</li></ul>"
 }
 
 test_Sites_Disabled_Incorrect_V5 if {
@@ -392,7 +395,8 @@ test_Sites_Disabled_Incorrect_V5 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails ==
+        "The following OUs are non-compliant:<ul><li>Test Top-Level OU: Service status for Sites is ON.</li></ul>"
 }
 
 test_Sites_Disabled_Incorrect_V6 if {
@@ -425,6 +429,91 @@ test_Sites_Disabled_Incorrect_V6 if {
         "No relevant event in the current logs for the top-level OU, Test Top-Level OU. ",
         "While we are unable to determine the state from the logs, the default setting ",
         "is non-compliant; manual check recommended."
+    ])
+}
+
+test_Sites_Disabled_Incorrect_V7 if {
+    # Test Sites enabled in a group
+    PolicyId := "GWS.SITES.1.1v0.1"
+    Output := tests with input as {
+        "sites_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Sites"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Sites"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "group@example.com"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": ""
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails ==
+        "The following groups are non-compliant:<ul><li>group@example.com: Service status for Sites is ON.</li></ul>"
+}
+
+test_Sites_Disabled_Incorrect_V8 if {
+    # Test Sites enabled in a group and an ou
+    PolicyId := "GWS.SITES.1.1v0.1"
+    Output := tests with input as {
+        "sites_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Sites"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Sites"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "group@example.com"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": ""
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul><li>Test Top-Level OU: Service status for Sites is ON.</li></ul>",
+        "<br>",
+        "The following groups are non-compliant:<ul><li>group@example.com: Service status for Sites is ON.</li></ul>"
     ])
 }
 #--


### PR DESCRIPTION
## 🗣 Description ##
- Add group-setting support for Sites
- Add detailed report messages for Sites

### 💭 Motivation and context
Closes https://github.com/cisagov/ScubaGoggles/issues/193.
Closes https://github.com/cisagov/ScubaGoggles/issues/88.

## 📷 Screenshots (if appropriate) ##
![image](https://github.com/cisagov/ScubaGoggles/assets/106177711/91cd5295-afb0-457a-86ec-aa5363520273)



## 🧪 Testing
- Manually toggled service status for various OUs and groups. In all cases, output was as expected
- Updated unit tests

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
