### PR TITLE
Remove calls to old FilterEvents function

### DIFF
--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -32,7 +32,7 @@ NonCompliantOUs1_1 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "ChatArchivingProto chatsDefaultToOffTheRecord", OU)
+    Events := utils.FilterEventsOU(LogEvents, "ChatArchivingProto chatsDefaultToOffTheRecord", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
@@ -48,7 +48,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -62,7 +62,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "ChatArchivingProto chatsDefaultToOffTheRecord", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -80,7 +80,7 @@ NonCompliantOUs1_2 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents,  "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
+    Events := utils.FilterEventsOU(LogEvents,  "ChatArchivingProto allow_chat_archiving_setting_modification", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "true"
@@ -97,7 +97,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "ChatArchivingProto allow_chat_archiving_setting_modification"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -111,7 +111,7 @@ tests contains {
 }
 if {
     SettingName := "ChatArchivingProto allow_chat_archiving_setting_modification"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_2) == 0
 }
@@ -140,7 +140,7 @@ NonCompliantOUs2_1 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents,  "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
+    Events := utils.FilterEventsOU(LogEvents,  "DynamiteFileSharingSettingsProto external_file_sharing_setting", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "NO_FILES"
@@ -158,7 +158,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "DynamiteFileSharingSettingsProto external_file_sharing_setting"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -172,7 +172,7 @@ tests contains {
 }
 if {
     SettingName := "DynamiteFileSharingSettingsProto external_file_sharing_setting"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -199,7 +199,7 @@ NonCompliantOUs3_1 contains {
     ])
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "RoomOtrSettingsProto otr_state", OU)
+    Events := utils.FilterEventsOU(LogEvents, "RoomOtrSettingsProto otr_state", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     not contains("DEFAULT_ON_THE_RECORD ALWAYS_ON_THE_RECORD", LastEvent.NewValue)
@@ -215,7 +215,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -228,7 +228,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "RoomOtrSettingsProto otr_state", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -244,12 +244,12 @@ if {
 default NoSuchEvent4_1(_) := false
 
 NoSuchEvent4_1(TopLevelOU) := true if {
-    Events := utils.FilterEvents(LogEvents, "RestrictChatProto restrictChatToOrganization", TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "RestrictChatProto restrictChatToOrganization", TopLevelOU)
     count(Events) == 0
 }
 
 NoSuchEvent4_1(TopLevelOU) := true if {
-    Events := utils.FilterEvents(LogEvents, "RestrictChatProto externalChatRestriction", TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "RestrictChatProto externalChatRestriction", TopLevelOU)
     count(Events) == 0
 }
 
@@ -259,12 +259,12 @@ NonCompliantOUs4_1 contains {
 }
  if {
     some OU in utils.OUsWithEvents
-    Events_A := utils.FilterEvents(LogEvents, "RestrictChatProto restrictChatToOrganization", OU)
+    Events_A := utils.FilterEventsOU(LogEvents, "RestrictChatProto restrictChatToOrganization", OU)
     count(Events_A) > 0
     LastEvent_A := utils.GetLastEvent(Events_A)
     LastEvent_A.NewValue != "DELETE_APPLICATION_SETTING"
 
-    Events_B := utils.FilterEvents(LogEvents, "RestrictChatProto externalChatRestriction", OU)
+    Events_B := utils.FilterEventsOU(LogEvents, "RestrictChatProto externalChatRestriction", OU)
     count(Events_B) > 0
     LastEvent_B := utils.GetLastEvent(Events_B)
     LastEvent_B.NewValue != "DELETE_APPLICATION_SETTING"
@@ -316,7 +316,7 @@ NonCompliantOUs5_1 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "Chat app Settings - Chat apps enabled", OU)
+    Events := utils.FilterEventsOU(LogEvents, "Chat app Settings - Chat apps enabled", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -335,7 +335,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -348,7 +348,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents,  "Chat app Settings - Chat apps enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs5_1) == 0
 }
@@ -397,12 +397,12 @@ NonCompliantOUs7_1 contains OU if {
 
     # There is no one setting that corresponds to the "Allow users to report content in Chat" button.
     # That button in the UI acts more like a "Deselect all" button for the conversation types.
-    OneOnOneEvents := utils.FilterEvents(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
-    GroupEvents := utils.FilterEvents(LogEvents, "ContentReportingProto group_chat_reporting", OU)
-    SpacesEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_reporting", OU)
+    OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
+    GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
+    SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
 
     # This setting corresponds to the "All spaces" or "Discoverable spaces only" toggle under the Spaces box
-    SpacesRestrictionEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_restrictions", OU)
+    SpacesRestrictionEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_restrictions", OU)
 
     # Ignore OUs without all event types. We're already asserting that the
     # top-level OU has at least one event for all types; for all other OUs we assume
@@ -433,12 +433,12 @@ NonCompliantOUs7_1 contains OU if {
 
     # There is no one setting that corresponds to the "Allow users to report content in Chat" button.
     # That button in the UI acts more like a "Deselect all" button for the conversation types.
-    OneOnOneEvents := utils.FilterEvents(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
-    GroupEvents := utils.FilterEvents(LogEvents, "ContentReportingProto group_chat_reporting", OU)
-    SpacesEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_reporting", OU)
+    OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
+    GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
+    SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
 
     # This setting corresponds to the "All spaces" or "Discoverable spaces only" toggle under the Spaces box
-    SpacesRestrictionEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_restrictions", OU)
+    SpacesRestrictionEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_restrictions", OU)
 
     # Ignore OUs without all event types. We're already asserting that the
     # top-level OU has at least one event for all types; for all other OUs we assume
@@ -466,10 +466,10 @@ NonCompliantOUs7_1 contains OU if {
 default NoSuchEvent7_1 := false
 NoSuchEvent7_1 := true if {
     OU := utils.TopLevelOU
-    OneOnOneEvents := utils.FilterEvents(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
-    GroupEvents := utils.FilterEvents(LogEvents, "ContentReportingProto group_chat_reporting", OU)
-    SpacesEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_reporting", OU)
-    SpacesRestrictionEvents := utils.FilterEvents(LogEvents, "ContentReportingProto room_restrictions", OU)
+    OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
+    GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
+    SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
+    SpacesRestrictionEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_restrictions", OU)
 
     true in {
         count(OneOnOneEvents) == 0,
@@ -521,7 +521,7 @@ AllReportingCategories := {
 
 NonCompliantOUs7_2 contains OU if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "ContentReportingProto report_types", OU)
+    Events := utils.FilterEventsOU(LogEvents, "ContentReportingProto report_types", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -535,7 +535,7 @@ NonCompliantOUs7_2 contains OU if {
 
 NonCompliantOUs7_2 contains OU if {
     OU := utils.TopLevelOU
-    Events := utils.FilterEvents(LogEvents, "ContentReportingProto report_types", OU)
+    Events := utils.FilterEventsOU(LogEvents, "ContentReportingProto report_types", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -555,7 +555,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "ContentReportingProto report_types", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "ContentReportingProto report_types", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -568,7 +568,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "ContentReportingProto report_types", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "ContentReportingProto report_types", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs7_2) == 0
 }

--- a/rego/Classroom.rego
+++ b/rego/Classroom.rego
@@ -150,7 +150,7 @@ NonCompliantOUs2_1 contains {
     ])
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", OU)
+    Events := utils.FilterEventsOU(LogEvents, "ApiDataAccessSettingProto api_access_enabled", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -170,7 +170,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -184,7 +184,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "ApiDataAccessSettingProto api_access_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -211,7 +211,7 @@ NonCompliantOUs3_1 contains {
     ])
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", OU)
+    Events := utils.FilterEventsOU(LogEvents, "RosterImportSettingsProto sis_integrator", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -231,7 +231,7 @@ tests contains {
 }
 if {
     DefaultSafe := true
-    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -244,7 +244,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "RosterImportSettingsProto sis_integrator", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -271,7 +271,7 @@ NonCompliantOUs4_1 contains {
     ])
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
+    Events := utils.FilterEventsOU(LogEvents, "StudentUnenrollmentSettingsProto who_can_unenroll_students", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -292,7 +292,7 @@ tests contains {
 if {
     DefaultSafe := true
     SettingName := "StudentUnenrollmentSettingsProto who_can_unenroll_students"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -306,7 +306,7 @@ tests contains {
 }
 if {
     SettingName := "StudentUnenrollmentSettingsProto who_can_unenroll_students"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -25,7 +25,7 @@ NonCompliantOUs1_1 contains {
 } 
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", OU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyDomainLockProto users_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
@@ -42,7 +42,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -56,7 +56,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
     # as long as it is not all, this is disabled.
@@ -84,7 +84,7 @@ NonCompliantOUs2_1 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", OU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "ALL"
@@ -101,7 +101,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -114,7 +114,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -141,7 +141,7 @@ NonCompliantOUs3_1 contains {
 }
 if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", OU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyModerationLockProto host_management_enabled", OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -158,7 +158,7 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -171,7 +171,7 @@ tests contains {
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -198,7 +198,7 @@ NonCompliantOUs4_1 contains {
 if {
     some OU in utils.OUsWithEvents
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(LogEvents, SettingName, OU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, OU)
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue == "false"
@@ -216,7 +216,7 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
@@ -230,7 +230,7 @@ tests contains {
 }
 if {
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }


### PR DESCRIPTION
## 🗣 Description ##
Replaced the calls to the old `utils.FilterEvents` function with the new `utils.FilterEventsOU` function for Chat, Classroom, and Meet.

### 💭 Motivation and context
Contributes to but does not close not close https://github.com/cisagov/ScubaGoggles/issues/265.

## 🧪 Testing
- Unit tests still all pass
- Reports from before and after the change match exactly, as expected.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
