### PR TITLE
Detailed report message for GWS.CHAT.7

### DIFF
--- a/Testing/RegoTests/chat/chat07_test.rego
+++ b/Testing/RegoTests/chat/chat07_test.rego
@@ -576,7 +576,7 @@ test_Categories_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Categories_Correct_V2 if {
@@ -630,7 +630,7 @@ test_Categories_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Categories_Correct_V3 if {
@@ -676,7 +676,7 @@ test_Categories_Correct_V3 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_Categories_Incorrect_V1 if {
@@ -712,7 +712,10 @@ test_Categories_Incorrect_V1 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Top-Level OU: The following reporting types are disabled: other</li></ul>"
+    ])
 }
 
 test_Categories_Incorrect_V2 if {
@@ -766,7 +769,10 @@ test_Categories_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Other OU."
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Other OU: The following reporting types are disabled: harassment</li></ul>"
+    ])
 }
 
 test_Categories_Incorrect_V3 if {

--- a/Testing/RegoTests/chat/chat07_test.rego
+++ b/Testing/RegoTests/chat/chat07_test.rego
@@ -59,7 +59,7 @@ test_Enable_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == concat("<br>", ["Requirement met in all OUs and groups.", Chat7Warning])
 }
 
 test_Enable_Correct_V2 if {
@@ -157,7 +157,7 @@ test_Enable_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == concat("<br>", ["Requirement met in all OUs and groups.", Chat7Warning])
 }
 
 test_Enable_Correct_V3 if {
@@ -255,7 +255,7 @@ test_Enable_Correct_V3 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == concat("<br>", ["Requirement met in all OUs and groups.", Chat7Warning])
 }
 
 test_Enable_Incorrect_V1 if {
@@ -313,7 +313,12 @@ test_Enable_Incorrect_V1 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Top-Level OU: Content reporting for 1:1 direct messages is disabled.</li></ul>",
+        "<br>",
+        Chat7Warning
+    ])
 }
 
 test_Enable_Incorrect_V2 if {
@@ -371,7 +376,12 @@ test_Enable_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Top-Level OU: Content reporting for spaces is restricted to discoverable spaces only.</li></ul>",
+        "<br>",
+        Chat7Warning
+    ])
 }
 
 test_Enable_Incorrect_V3 if {
@@ -469,7 +479,12 @@ test_Enable_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Other OU."
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Other OU: Content reporting for spaces is disabled.</li></ul>",
+        "<br>",
+        Chat7Warning
+    ])
 }
 
 test_Enable_Incorrect_V4 if {

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -546,10 +546,9 @@ AllReportingCategories := {
     "system_violation: OTHER"
 }
 
-GetFriendlyCategory(Category) := FriendlyCategory {
+GetFriendlyCategory(Category) := FriendlyCategory if {
     SplitStr := split(Category, " ")
-    LastIndex = count(SplitStr)-1
-    LastWord := SplitStr[LastIndex]
+    LastWord := SplitStr[1]
     FriendlyCategory := replace(lower(LastWord), "_", " ")
 }
 

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -406,6 +406,7 @@ GetFriendlyValue7_1(NonCompBooleans) := Description if {
     ]
     # Note that this logic assumes the order of the booleans corresponds to the order listed above in the
     # StatusMessages array
+    # regal ignore:prefer-some-in-iteration ignore:use-some-for-output-vars
     Description := concat(" ", [StatusMessages[i] | some i, Status in NonCompBooleans; Status == true])
 }
 

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -390,7 +390,7 @@ Chat7Warning := concat("", [
     "WARNING: from the log events alone, it is not possible to distinguish between ",
     "an OU inheriting settings from its parent and content reporting being disabled entirely. ",
     "It's possible this tool classified some child OUs as compliant due to this limitation; manual check ",
-    "recommended to for child OUs due to this edge case."
+    "recommended for child OUs due to this edge case."
 ])
 
 #

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -406,7 +406,7 @@ GetFriendlyValue7_1(NonCompBooleans) := Description if {
     ]
     # Note that this logic assumes the order of the booleans corresponds to the order listed above in the
     # StatusMessages array
-    # regal ignore:prefer-some-in-iteration ignore:use-some-for-output-vars
+    # regal ignore:prefer-some-in-iteration,use-some-for-output-vars
     Description := concat(" ", [StatusMessages[i] | some i, Status in NonCompBooleans; Status == true])
 }
 

--- a/rego/Chat.rego
+++ b/rego/Chat.rego
@@ -375,28 +375,51 @@ tests contains {
 # GWS.CHAT.7 #
 ##############
 
+# There is no setting that corresponds to the "Allow users to report content in Chat" button.
+# That button in the UI acts more like a "Deselect all" button for the conversation types.
+# Additionally, there is a quirk with it that makes it necessary for the top-level OU to be
+# handled separately.
+# 1. Setting a child OU to inherit results in DELETE_APPLICATION_SETTING events, as expected.
+# 2. Deselecting the "Allow users to report content in Chat" also results in
+# DELETE_APPLICATION_SETTING events, completely indistinguishable from the inheritance events.
+# We know the top-level OU can't inherit, so if we see that there we know they turned off
+# content reporting.
+# Unfortunately, for the child OUs, from the log events alone you cannot distinguish between
+# setting inheritance and completely disabling content reporting.
+Chat7Warning := concat("", [
+    "WARNING: from the log events alone, it is not possible to distinguish between ",
+    "an OU inheriting settings from its parent and content reporting being disabled entirely. ",
+    "It's possible this tool classified some child OUs as compliant due to this limitation; manual check ",
+    "recommended to for child OUs due to this edge case."
+])
+
 #
 # GWS.CHAT.7.1v0.1
 #--
-NonCompliantOUs7_1 contains OU if {
-    # NOTE: The top-level OU needs to be handled separately in this case, as the log event for
-    # disabling a conversation type does not follow the typical pattern of most admin log events.
-    # - Setting a child OU to inherit results in a DELETE_APPLICATION_SETTING event, as expected.
-    # - Disabling a conversation type in the top-level OU also results in a
-    #   DELETE_APPLICATION_SETTING event -- a deviation from the normal pattern.
-    # Typically, we assume inheritance whenever we see a DELETE_APPLICATION_SETTING event, but due
-    # to the above quirk we need more fine-tuned logic.
-    #
-    # Also worth noting is that disabling a conversation type in a child OU *does not* result in a
-    # DELETE_APPLICATION_SETTING event as it does in the top-level OU. Instead it results in either
-    # a CREATE_APPLICATION_SETTING or CHANGE_APPLICATION_SETTING event (depending on if the OU had
-    # already overwridden the top-level OU settings), with the new value set to
-    # CONTENT_REPORTING_STATE_DISABLED.
+
+GetFriendlyValue7_1(NonCompBooleans) := Description if {
+    StatusMessages = [
+        "Content reporting for 1:1 direct messages is disabled.",
+        "Content reporting for group direct messages is disabled.",
+        "Content reporting for spaces is disabled.",
+        "Content reporting for spaces is restricted to discoverable spaces only."
+    ]
+    # Note that this logic assumes the order of the booleans corresponds to the order listed above in the
+    # StatusMessages array
+    Description := concat(" ", [
+        StatusMessages[i] | some i in numbers.range(0, count(StatusMessages)-1); NonCompBooleans[i] == true
+    ])
+}
+
+NonCompliantOUs7_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue7_1(NonCompBooleans)
+} if {
     some OU in utils.OUsWithEvents
+    # Toplevel OU will be handled separately due to the quirk with DELETE_APPLICATION_SETTING events for
+    # these settings.
     OU != utils.TopLevelOU
 
-    # There is no one setting that corresponds to the "Allow users to report content in Chat" button.
-    # That button in the UI acts more like a "Deselect all" button for the conversation types.
     OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
     GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
     SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
@@ -419,20 +442,22 @@ NonCompliantOUs7_1 contains OU if {
     LastEventSpaceRestriction := utils.GetLastEvent(SpacesRestrictionEvents)
 
     # A child-OU is non-compliant if any of the following are true
-    true in {
+    NonCompBooleans := [
         LastEventOneOnOne.NewValue == "CONTENT_REPORTING_STATE_DISABLED",
         LastEventGroup.NewValue == "CONTENT_REPORTING_STATE_DISABLED",
         LastEventSpaces.NewValue == "CONTENT_REPORTING_STATE_DISABLED",
         LastEventSpaceRestriction.NewValue == "SPACE_RESTRICTIONS_DISCOVERABLE_SPACES_ONLY"
-    }
+    ]
+    true in NonCompBooleans
 }
 
-NonCompliantOUs7_1 contains OU if {
+NonCompliantOUs7_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue7_1(NonCompBooleans)
+} if {
     # NOTE: the top-level OU is a special case, see comments above.
     OU := utils.TopLevelOU
 
-    # There is no one setting that corresponds to the "Allow users to report content in Chat" button.
-    # That button in the UI acts more like a "Deselect all" button for the conversation types.
     OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
     GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
     SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
@@ -455,12 +480,16 @@ NonCompliantOUs7_1 contains OU if {
     LastEventSpaceRestriction := utils.GetLastEvent(SpacesRestrictionEvents)
 
     # The top-level OU is non-compliant if any of the following are true
-    true in {
-        LastEventOneOnOne.NewValue != "CONTENT_REPORTING_STATE_ENABLED",
-        LastEventGroup.NewValue != "CONTENT_REPORTING_STATE_ENABLED",
-        LastEventSpaces.NewValue != "CONTENT_REPORTING_STATE_ENABLED",
-        LastEventSpaceRestriction.NewValue != "SPACE_RESTRICTIONS_NO_RESTRICTIONS"
-    }
+    NonCompBooleans := [
+        LastEventOneOnOne.NewValue in {"CONTENT_REPORTING_STATE_DISABLED", "DELETE_APPLICATION_SETTING"},
+        LastEventGroup.NewValue in {"CONTENT_REPORTING_STATE_DISABLED", "DELETE_APPLICATION_SETTING"},
+        LastEventSpaces.NewValue in {"CONTENT_REPORTING_STATE_DISABLED", "DELETE_APPLICATION_SETTING"},
+        LastEventSpaceRestriction.NewValue in {
+            "SPACE_RESTRICTIONS_DISCOVERABLE_SPACES_ONLY",
+            "DELETE_APPLICATION_SETTING"
+        }
+    ]
+    true in NonCompBooleans
 }
 
 default NoSuchEvent7_1 := false
@@ -495,7 +524,7 @@ if {
 tests contains {
     "PolicyId": "GWS.CHAT.7.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs7_1),
+    "ReportDetails": concat("<br>", [utils.ReportDetails(NonCompliantOUs7_1, []), Chat7Warning]),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs7_1},
     "RequirementMet": Status,
     "NoSuchEvent": false


### PR DESCRIPTION
## 🗣 Description ##
Adds detailed report messages to GWS.CHAT.7.1 and GWS.CHAT.7.2. Additionally, corrects a bug with how DELETE_APPLICATION_SETTING events were handled for these settings.

### 💭 Motivation and context
Closes #210.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
- Updated unit tests
- Make various tweaks in the admin center and verified the report was correct

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
