### PR TITLE
Update README.md to clarify authentication instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,8 @@ OAuth requires regular user consent while using a service account allows for mor
 Follow the instructions below for the authentication method of your choice.
 
 
-#### Create an OAuth credential
+#### Using OAuth
+##### Create an OAuth credential
 1. Be signed into http://console.cloud.google.com/.
 1. From the hamburger menu on the left, select **APIs & Services** -> **OAuth consent screen**
 1. Select **Internal** for **User Type**
@@ -208,7 +209,7 @@ If you've limited application access to Google's APIs in your organization, the 
 #### Using a Service Account
 
 > [!Important]
-> ScubaGoggles requires the service account to have [domain-wide delegation of authority](https://support.google.com/a/answer/162106?hl=en) to function. 
+> ScubaGoggles requires the service account to have [domain-wide delegation of authority](https://support.google.com/a/answer/162106?hl=en) to function. Only complete this section if not authenticating via OAuth credential (see [Using OAuth](#using-oauth)).
 
 1. Login to https://console.cloud.google.com and navigate to your GCP project.
 1. From the hamburger menu, select **IAM & Admin** -> **Service Accounts**


### PR DESCRIPTION
## 🗣 Description ##
- Update the section headers to clarify that OAuth and service accounts are parallel paths
- Add note that service account instructions only apply if not using OAuth credential

### 💭 Motivation and context
The instructions as it was before could have been more clear (see #291).

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
N/A


## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
