### PR TITLE
#new-87-detailed-report-message-for-groups

### DIFF
--- a/Testing/RegoTests/groups/groups01_test.rego
+++ b/Testing/RegoTests/groups/groups01_test.rego
@@ -30,7 +30,7 @@ test_GroupAccess_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupAccess_Correct_V2 if {
@@ -68,7 +68,7 @@ test_GroupAccess_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupsAccess_Incorrect_V1 if {
@@ -129,7 +129,8 @@ test_GroupAccess_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group access from outside the organization is enabled</li></ul>"])
 }
 #TODO
 test_GroupAccess_Incorrect_V3 if {
@@ -167,6 +168,7 @@ test_GroupAccess_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group access from outside the organization is enabled</li></ul>"])
 }
 #--

--- a/Testing/RegoTests/groups/groups02_test.rego
+++ b/Testing/RegoTests/groups/groups02_test.rego
@@ -33,7 +33,7 @@ test_GroupAddExternal_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupAddExternal_Correct_V2 if {
@@ -78,7 +78,7 @@ test_GroupAddExternal_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupAddExternal_Incorrect_V1 if {
@@ -141,7 +141,8 @@ test_GroupAddExternal_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group owner has the ability to add external members to the group</li></ul>"])
 }
 
 test_GroupAddExternal_Incorrect_V3 if {
@@ -185,6 +186,7 @@ test_GroupAddExternal_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group owner has the ability to add external members to the group</li></ul>"])
 }
 #--

--- a/Testing/RegoTests/groups/groups03_test.rego
+++ b/Testing/RegoTests/groups/groups03_test.rego
@@ -33,7 +33,7 @@ test_GroupIncomingMailPosting_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupIncomingMailPosting_Correct_V2 if {
@@ -78,7 +78,7 @@ test_GroupIncomingMailPosting_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupIncomingMailPosting_Incorrect_V1 if {
@@ -142,7 +142,9 @@ test_GroupIncomingMailPosting_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group owner has the ability to allow an ",
+        "external non-member to post to the group</li></ul>"])
 }
 
 test_GroupIncomingMailPosting_Incorrect_V3 if {
@@ -187,6 +189,8 @@ test_GroupIncomingMailPosting_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group owner has the ability to allow an ",
+        "external non-member to post to the group</li></ul>"])
 }
 #--

--- a/Testing/RegoTests/groups/groups04_test.rego
+++ b/Testing/RegoTests/groups/groups04_test.rego
@@ -30,7 +30,7 @@ test_GroupCreation_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 test_GroupCreation_Correct_V2 if {
     # Test group creation restrictions when there's multiple events and the most most recent is correct
@@ -67,7 +67,7 @@ test_GroupCreation_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupCreation_Incorrect_V1 if {
@@ -127,7 +127,8 @@ test_GroupCreation_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails =="Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group creation ability is not restricted to admins within the organization</li></ul>"])
 }
 
 test_GroupCreation_Incorrect_V3 if {
@@ -165,6 +166,7 @@ test_GroupCreation_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Group creation ability is not restricted to admins within the organization</li></ul>"])
 }
 #--

--- a/Testing/RegoTests/groups/groups05_test.rego
+++ b/Testing/RegoTests/groups/groups05_test.rego
@@ -33,7 +33,7 @@ test_GroupConservationViewPermission_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupConservationViewPermission_Correct_V2 if {
@@ -77,7 +77,7 @@ test_GroupConservationViewPermission_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails =="Requirement met in all OUs."
+    RuleOutput[0].ReportDetails =="Requirement met in all OUs and groups."
 }
 
 test_GroupConservationViewPermission_Incorrect_V1 if {
@@ -140,7 +140,8 @@ test_GroupConservationViewPermission_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to domain users</li></ul>"])
 }
 
 test_GroupConservationViewPermission_Incorrect_V3 if {
@@ -171,7 +172,8 @@ test_GroupConservationViewPermission_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to managers</li></ul>"])
 }
 
 test_GroupConservationViewPermission_Incorrect_V4 if {
@@ -202,7 +204,8 @@ test_GroupConservationViewPermission_Incorrect_V4 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to owners</li></ul>"])
 }
 
 test_GroupConservationViewPermission_Incorrect_V5 if {
@@ -246,7 +249,8 @@ test_GroupConservationViewPermission_Incorrect_V5 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to domain users</li></ul>"])
 }
 
 test_GroupConservationViewPermission_Incorrect_V6 if {
@@ -290,7 +294,8 @@ test_GroupConservationViewPermission_Incorrect_V6 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to managers</li></ul>"])
 }
 
 test_GroupConservationViewPermission_Incorrect_V7 if {
@@ -334,6 +339,7 @@ test_GroupConservationViewPermission_Incorrect_V7 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Permission to view conversations is set to owners</li></ul>"])
 }
 #--

--- a/Testing/RegoTests/groups/groups06_test.rego
+++ b/Testing/RegoTests/groups/groups06_test.rego
@@ -30,7 +30,7 @@ test_GroupOwnersHideGroups_Correct_V1 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupOwnersHideGroups_Correct_V2 if {
@@ -68,7 +68,7 @@ test_GroupOwnersHideGroups_Correct_V2 if {
     count(RuleOutput) == 1
     RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement met in all OUs."
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
 test_GroupOwnersHideGroups_Incorrect_V1 if {
@@ -128,7 +128,8 @@ test_GroupOwnersHideGroups_Incorrect_V2 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Groups can be hidden from the directory</li></ul>"])
 }
 
 test_GroupOwnersHideGroups_Incorrect_V3 if {
@@ -166,7 +167,8 @@ test_GroupOwnersHideGroups_Incorrect_V3 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Groups can be hidden from the directory</li></ul>"])
 }
 
 test_GroupOwnersHideGroups_Incorrect_V4 if {
@@ -203,6 +205,7 @@ test_GroupOwnersHideGroups_Incorrect_V4 if {
     count(RuleOutput) == 1
     not RuleOutput[0].RequirementMet
     not RuleOutput[0].NoSuchEvent
-    RuleOutput[0].ReportDetails == "Requirement failed in Test Top-Level OU."
+    RuleOutput[0].ReportDetails == concat("", ["The following OUs are non-compliant:<ul><li>Test Top-Level OU: ",
+        "Groups can be hidden from the directory</li></ul>"])
 }
 #--

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -12,7 +12,19 @@ LogEvents := utils.GetEvents("groups_logs")
 #
 # Baseline GWS.GROUPS.1.1v0.1
 #--
-NonCompliantOUs1_1 contains OU if {
+
+GetFriendlyValue1_1(Value) :=
+"disabled" if {
+    Value != "CLOSED"
+} else := "enabled" if {
+    Value == "OPEN"
+} else := Value
+
+NonCompliantOUs1_1 contains {
+    "Name": OU,
+    "Value": concat(["Group access from outside the organization is ",
+        GetFriendlyValue1_1(LastEvent.NewValue)])
+} if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", OU)
     # Ignore OUs without any events. We're already asserting that the
@@ -60,7 +72,19 @@ if {
 #
 # Baseline GWS.GROUPS.2.1v0.1
 #--
-NonCompliantOUs2_1 contains OU if {
+
+GetFriendlyValue2_1(Value) :=
+"Group owner has the ability to add external members to the group" if {
+    Value != "false"
+} else := "Group owner does not have the ability to
+    add external members to the group" if {
+    Value == "false"
+} else := Value
+
+NonCompliantOUs2_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue2_1(LastEvent.NewValue)
+} if {
     some OU in utils.OUsWithEvents
     SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
     Events := utils.FilterEvents(LogEvents, SettingName, OU)
@@ -110,7 +134,20 @@ if {
 #
 # Baseline GWS.GROUPS.3.1v0.1
 #--
-NonCompliantOUs3_1 contains OU if {
+
+GetFriendlyValue3_1(Value) :=
+"Group owner has the ability to allow an
+    external non-member to post to the group" if {
+    Value != "false"
+} else := "Group owner does not have the ability to allow an
+    external non-member to post to the group" if {
+    Value == "false"
+} else := Value
+
+NonCompliantOUs3_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue3_1(LastEvent.NewValue)
+} if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
     # Ignore OUs without any events. We're already asserting that the
@@ -160,7 +197,16 @@ if {
 #
 # Baseline GWS.GROUPS.4.1v0.1
 #--
-NonCompliantOUs4_1 contains OU if {
+
+GetFriendlyValue4_1(Value) :=
+"Group creation ability is not restricted to admins within the organization" if {
+    Value != "ADMIN_ONLY"
+}
+
+NonCompliantOUs4_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue4_1(LastEvent.NewValue)
+} if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", OU)
     # Ignore OUs without any events. We're already asserting that the
@@ -208,7 +254,16 @@ if {
 #
 # Baseline GWS.GROUPS.5.1v0.1
 #--
-NonCompliantOUs5_1 contains OU if {
+
+GetFriendlyValue5_1(Value) := 
+"Permission to view conversations is not set to all group members" if {
+    Value != "MEMBERS"
+}
+
+NonCompliantOUs5_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue5_1(LastEvent.NewValue)
+    } if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto default_view_topics_access_level", OU)
     # Ignore OUs without any events. We're already asserting that the
@@ -265,7 +320,16 @@ CheckGroups6_1Compliance(Events, OUs) := true if {
 }
 else := false
 
-NonCompliantOUs6_1 contains OU if {
+GetFriendlyValue6_1(Value) := "Groups can be hidden from the directory" if {
+    Value == "true"
+} else := "Groups cannot be hidden from the directory" if {
+    Value == "false"
+} else := Value
+
+NonCompliantOUs6_1 contains {
+    "Name": OU,
+    "Value": GetFriendlyValue6_1(LastEvent.NewValue)
+    } if {
     some OU in utils.OUsWithEvents
     Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", OU)
     # Ignore OUs without any events. We're already asserting that the

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -15,7 +15,7 @@ LogEvents := utils.GetEvents("groups_logs")
 
 GetFriendlyValue1_1(Value) :=
 "disabled" if {
-    Value != "CLOSED"
+    Value == "CLOSED"
 } else := "enabled" if {
     Value == "OPEN"
 } else := Value
@@ -26,7 +26,7 @@ NonCompliantOUs1_1 contains {
         GetFriendlyValue1_1(LastEvent.NewValue)])
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", OU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto collaboration_policy", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -45,20 +45,20 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.1.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs1_1),
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs1_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto collaboration_policy", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs1_1) == 0
 }
@@ -87,7 +87,7 @@ NonCompliantOUs2_1 contains {
 } if {
     some OU in utils.OUsWithEvents
     SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
-    Events := utils.FilterEvents(LogEvents, SettingName, OU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -107,21 +107,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.2.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs2_1),
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs2_1, []),
     "ActualValue": {"NonCompliantOUs":NonCompliantOUs2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "GroupsSharingSettingsProto owners_can_allow_external_members"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs2_1) == 0
 }
@@ -148,7 +148,7 @@ NonCompliantOUs3_1 contains {
     "Value": GetFriendlyValue3_1(LastEvent.NewValue)
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -168,21 +168,21 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.3.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs3_1),
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs3_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     SettingName := "GroupsSharingSettingsProto owners_can_allow_incoming_mail_from_public"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs3_1) == 0
 }
@@ -207,7 +207,7 @@ NonCompliantOUs4_1 contains {
     "Value": GetFriendlyValue4_1(LastEvent.NewValue)
 } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", OU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -226,20 +226,20 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.4.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs4_1),
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs4_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto who_can_create_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs4_1) == 0
 }
@@ -254,17 +254,21 @@ if {
 # Baseline GWS.GROUPS.5.1v0.1
 #--
 
-GetFriendlyValue5_1(Value) := 
-"Permission to view conversations is not set to all group members" if {
-    Value != "MEMBERS"
-}
+GetFriendlyValue5_1(Value) := "owners"
+ if {
+    Value == "OWNERS"
+} else := "managers" if {
+    Value == "MANAGERS"
+} else := "domain users" if {
+    Value == "DOMAIN_USERS"
+} else := Value
 
 NonCompliantOUs5_1 contains {
     "Name": OU,
-    "Value": GetFriendlyValue5_1(LastEvent.NewValue)
+    "Value": concat("", ["Permission to view conversations is set to ", GetFriendlyValue5_1(LastEvent.NewValue)])
     } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto default_view_topics_access_level", OU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto default_view_topics_access_level", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -284,14 +288,14 @@ tests contains {
 if {
     DefaultSafe := false
     SettingName := "GroupsSharingSettingsProto default_view_topics_access_level"
-    Events := utils.FilterEvents(LogEvents, SettingName, utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.5.1v0.1",
     "Criticality": "Should",
-    "ReportDetails": utils.ReportDetailsOUs(NonCompliantOUs5_1),
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs5_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
@@ -330,7 +334,7 @@ NonCompliantOUs6_1 contains {
     "Value": GetFriendlyValue6_1(LastEvent.NewValue)
     } if {
     some OU in utils.OUsWithEvents
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", OU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", OU)
     # Ignore OUs without any events. We're already asserting that the
     # top-level OU has at least one event; for all other OUs we assume
     # they inherit from a parent OU if they have no events.
@@ -349,20 +353,20 @@ tests contains {
 }
 if {
     DefaultSafe := false
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) == 0
 }
 
 tests contains {
     "PolicyId": "GWS.GROUPS.6.1v0.1",
     "Criticality": "Shall",
-    "ReportDetails":utils.ReportDetailsOUs(NonCompliantOUs6_1),
+    "ReportDetails":utils.ReportDetails(NonCompliantOUs6_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs6_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
-    Events := utils.FilterEvents(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
+    Events := utils.FilterEventsOU(LogEvents, "GroupsSharingSettingsProto allow_unlisted_groups", utils.TopLevelOU)
     count(Events) > 0
     Status := count(NonCompliantOUs6_1) == 0
 }

--- a/rego/Groups.rego
+++ b/rego/Groups.rego
@@ -22,7 +22,7 @@ GetFriendlyValue1_1(Value) :=
 
 NonCompliantOUs1_1 contains {
     "Name": OU,
-    "Value": concat(["Group access from outside the organization is ",
+    "Value": concat("", ["Group access from outside the organization is ",
         GetFriendlyValue1_1(LastEvent.NewValue)])
 } if {
     some OU in utils.OUsWithEvents
@@ -76,8 +76,8 @@ if {
 GetFriendlyValue2_1(Value) :=
 "Group owner has the ability to add external members to the group" if {
     Value != "false"
-} else := "Group owner does not have the ability to
-    add external members to the group" if {
+} else := concat("", ["Group owner does not have the ability to ",
+    "add external members to the group"]) if {
     Value == "false"
 } else := Value
 
@@ -135,12 +135,11 @@ if {
 # Baseline GWS.GROUPS.3.1v0.1
 #--
 
-GetFriendlyValue3_1(Value) :=
-"Group owner has the ability to allow an
-    external non-member to post to the group" if {
+GetFriendlyValue3_1(Value) := concat("", ["Group owner has the ability to allow an ",
+    "external non-member to post to the group"]) if {
     Value != "false"
-} else := "Group owner does not have the ability to allow an
-    external non-member to post to the group" if {
+} else := concat("", ["Group owner does not have the ability to allow an ",
+    "external non-member to post to the group"]) if {
     Value == "false"
 } else := Value
 


### PR DESCRIPTION
## 🗣 Description ##

Detailed report messages for Groups

### 💭 Motivation and context

This issue is part of epic #90 

## 🧪 Testing

All reports and unit tests should pass all use cases

Note: Policy 7 is not updated with detailed report message. If it is applicable this can be handled as a separate issue post Barracuda release.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
