### PR TITLE
meet: implement group checks (issue 320)

### DIFF
--- a/Testing/RegoTests/meet/meet02_test.rego
+++ b/Testing/RegoTests/meet/meet02_test.rego
@@ -555,3 +555,52 @@ test_JoinExternalPers_Incorrect_V7 if {
     "What meetings can org users join is set to any meetings, ",
     "including meetings created with personal accounts</li></ul>"])
 }
+
+test_JoinExternalPers_Incorrect_V8 if {
+    # Test group wrong
+    PolicyId := "GWS.MEET.2.1v0.2"
+    Output := tests with input as {
+        "meet_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "SafetyAccessLockProto meetings_allowed_to_join"
+                        },
+                        {"name": "NEW_VALUE", "value": "SAME_DOMAIN"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "SafetyAccessLockProto meetings_allowed_to_join"
+                        },
+                        {"name": "NEW_VALUE", "value": "ALL"},
+                        {"name": "GROUP_EMAIL", "value": "group@example.com"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following groups are non-compliant:<ul>",
+        "<li>group@example.com: What meetings can org users join is set to ",
+        "any meetings, including meetings created with personal accounts</li>",
+        "</ul>"
+    ])
+}

--- a/Testing/RegoTests/meet/meet03_test.rego
+++ b/Testing/RegoTests/meet/meet03_test.rego
@@ -328,3 +328,51 @@ test_HostMan_Incorrect_V5 if {
     ])
 }
 #--
+
+test_HostMan_Incorrect_V6 if {
+    # Test group wrong
+    PolicyId := "GWS.MEET.3.1v0.2"
+    Output := tests with input as {
+        "meet_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "SafetyModerationLockProto host_management_enabled"
+                        },
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value": "SafetyModerationLockProto host_management_enabled"
+                        },
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "GROUP_EMAIL", "value": "group@example.com"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following groups are non-compliant:<ul>",
+        "<li>group@example.com: Host management when video calls start is set to off</li>",
+        "</ul>"
+    ])
+}

--- a/Testing/RegoTests/meet/meet04_test.rego
+++ b/Testing/RegoTests/meet/meet04_test.rego
@@ -128,7 +128,7 @@ test_HostMan_Correct_V3 if {
     RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
 }
 
-test_Access_Correct_V4 if {
+test_HostMan_Correct_V4 if {
     # Test history setting when set to inherit from parent
     PolicyId := "GWS.MEET.4.1v0.2"
     Output := tests with input as {
@@ -384,3 +384,54 @@ test_HostMan_Incorrect_V5 if {
     ])
 }
 #--
+
+test_HostMan_Incorrect_V6 if {
+    # Test group wrong
+    PolicyId := "GWS.MEET.4.1v0.2"
+    Output := tests with input as {
+        "meet_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "parameters": [
+                        {
+                            "name": "SETTING_NAME",
+                            "value":
+                "Warn for external participants External or unidentified participants in a meeting are given a label"
+                        },
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "GROUP_EMAIL", "value": "group@example.com"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following groups are non-compliant:<ul>",
+        "<li>group@example.com: Warning label for external or unidentified ",
+        "meeting participants is set to no warning label</li>",
+        "</ul>"
+    ])
+}

--- a/rego/Meet.rego
+++ b/rego/Meet.rego
@@ -32,6 +32,23 @@ if {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
+NonCompliantGroups1_1 contains {
+    "Name": Group,
+    "Value": concat(" ", [
+        "Who can join meetings is set to",
+        GetFriendlyValue1_1(LastEvent.NewValue)
+    ])
+}
+if {
+    some Group in utils.GroupsWithEvents
+    SettingName := "SafetyDomainLockProto users_allowed_to_join"
+    Events := utils.FilterEventsGroup(LogEvents, SettingName, Group)
+    count(Events) > 0
+    LastEvent := utils.GetLastEvent(Events)
+    LastEvent.NewValue == "ALL"
+    LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
+}
+
 tests contains {
     "PolicyId": "GWS.MEET.1.1v0.2",
     "Criticality": "Should",
@@ -49,20 +66,18 @@ if {
 tests contains {
     "PolicyId": "GWS.MEET.1.1v0.2",
     "Criticality": "Should",
-    # Empty list in next line for non-compliant groups, as Meet settings can't be changed at the group level
-    "ReportDetails": utils.ReportDetails(NonCompliantOUs1_1, []),
-    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs1_1, NonCompliantGroups1_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1, "NonCompliantGroups": NonCompliantGroups1_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     Events := utils.FilterEventsOU(LogEvents, "SafetyDomainLockProto users_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
-    Status := count(NonCompliantOUs1_1) == 0
-    # as long as it is not all, this is disabled.
+    Conditions := {count(NonCompliantOUs1_1) == 0, count(NonCompliantGroups1_1) == 0}
+    Status := (false in Conditions) == false
 }
 #--
-
 
 ##############
 # GWS.MEET.2 #
@@ -91,6 +106,23 @@ if {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
+NonCompliantGroups2_1 contains {
+    "Name": Group,
+    "Value": concat(" ", [
+        "What meetings can org users join is set to",
+        GetFriendlyValue2_1(LastEvent.NewValue)
+    ])
+}
+if {
+    some Group in utils.GroupsWithEvents
+    SettingName := "SafetyAccessLockProto meetings_allowed_to_join"
+    Events := utils.FilterEventsGroup(LogEvents, SettingName, Group)
+    count(Events) > 0
+    LastEvent := utils.GetLastEvent(Events)
+    LastEvent.NewValue == "ALL"
+    LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
+}
+
 tests contains {
     "PolicyId": "GWS.MEET.2.1v0.2",
     "Criticality": "Shall",
@@ -108,18 +140,18 @@ if {
 tests contains {
     "PolicyId": "GWS.MEET.2.1v0.2",
     "Criticality": "Shall",
-    "ReportDetails": utils.ReportDetails(NonCompliantOUs2_1, []),
-    "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs2_1, NonCompliantGroups2_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1, "NonCompliantGroups": NonCompliantGroups2_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     Events := utils.FilterEventsOU(LogEvents, "SafetyAccessLockProto meetings_allowed_to_join", utils.TopLevelOU)
     count(Events) > 0
-    Status := count(NonCompliantOUs2_1) == 0
+    Conditions := {count(NonCompliantOUs2_1) == 0, count(NonCompliantGroups2_1) == 0}
+    Status := (false in Conditions) == false
 }
 #--
-
 
 ##############
 # GWS.MEET.3 #
@@ -148,6 +180,23 @@ if {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
+NonCompliantGroups3_1 contains {
+    "Name": Group,
+    "Value": concat(" ", [
+        "Host management when video calls start is set to",
+        GetFriendlyValue3_1(LastEvent.NewValue)
+    ])
+}
+if {
+    some Group in utils.GroupsWithEvents
+    SettingName := "SafetyModerationLockProto host_management_enabled"
+    Events := utils.FilterEventsGroup(LogEvents, SettingName, Group)
+    count(Events) > 0
+    LastEvent := utils.GetLastEvent(Events)
+    LastEvent.NewValue == "false"
+    LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
+}
+
 tests contains {
         "PolicyId": "GWS.MEET.3.1v0.2",
         "Criticality": "Shall",
@@ -165,15 +214,16 @@ if {
 tests contains {
     "PolicyId": "GWS.MEET.3.1v0.2",
     "Criticality": "Shall",
-    "ReportDetails": utils.ReportDetails(NonCompliantOUs3_1, []),
-    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1},
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs3_1, NonCompliantGroups3_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs3_1, "NonCompliantGroups": NonCompliantGroups3_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
 if {
     Events := utils.FilterEventsOU(LogEvents, "SafetyModerationLockProto host_management_enabled", utils.TopLevelOU)
     count(Events) > 0
-    Status := count(NonCompliantOUs3_1) == 0
+    Conditions := {count(NonCompliantOUs3_1) == 0, count(NonCompliantGroups3_1) == 0}
+    Status := (false in Conditions) == false
 }
 #--
 
@@ -205,6 +255,23 @@ if {
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
 }
 
+NonCompliantGroups4_1 contains {
+    "Name": Group,
+    "Value": concat(" ", [
+        "Warning label for external or unidentified meeting participants is set to",
+        GetFriendlyValue4_1(LastEvent.NewValue)
+    ])
+}
+if {
+    some Group in utils.GroupsWithEvents
+    SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
+    Events := utils.FilterEventsGroup(LogEvents, SettingName, Group)
+    count(Events) > 0
+    LastEvent := utils.GetLastEvent(Events)
+    LastEvent.NewValue == "false"
+    LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
+}
+
 tests contains {
     "PolicyId": "GWS.MEET.4.1v0.2",
     "Criticality": "Shall",
@@ -223,8 +290,8 @@ if {
 tests contains {
     "PolicyId": "GWS.MEET.4.1v0.2",
     "Criticality": "Shall",
-    "ReportDetails": utils.ReportDetails(NonCompliantOUs4_1, []),
-    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
+    "ReportDetails": utils.ReportDetails(NonCompliantOUs4_1, NonCompliantGroups4_1),
+    "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1, "NonCompliantGroups": NonCompliantGroups4_1},
     "RequirementMet": Status,
     "NoSuchEvent": false
 }
@@ -232,7 +299,8 @@ if {
     SettingName := "Warn for external participants External or unidentified participants in a meeting are given a label"
     Events := utils.FilterEventsOU(LogEvents, SettingName, utils.TopLevelOU)
     count(Events) > 0
-    Status := count(NonCompliantOUs4_1) == 0
+    Conditions := {count(NonCompliantOUs4_1) == 0, count(NonCompliantGroups4_1) == 0}
+    Status := (false in Conditions) == false
 }
 #--
 


### PR DESCRIPTION
## 🗣 Description ##

Implemented checking of groups for GWS.MEET.1.1v0.2, GWS.MEET.2.1v0.2, GWS.MEET.3.1v0.2, and GWS.MEET.4.1v0.2.

### 💭 Motivation and context

Added checking for non-compliant groups in meet.rego for the 4 requirements.

Closes #320

## 🧪 Testing

Manually tested MEET 1-4 using scubagws.org admin settings on groups.

Added Rego tests for all 4 requirements.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
