### PR TITLE
Add support for user input and documentation improvements to smoke testing workflow

### DIFF
--- a/.github/actions/setup-dependencies-macos/action.yml
+++ b/.github/actions/setup-dependencies-macos/action.yml
@@ -1,6 +1,6 @@
 name: Setup Dependencies (macOS)
 inputs:
-  operating-system:
+  os:
     required: true
     default: "macos"
   opa-version:
@@ -26,11 +26,9 @@ runs:
         pip install -r requirements.txt
         pip install pytest
         pip install selenium
-        pip uninstall -y numpy
-        pip install numpy==1.26.4
-    
+
     - name: Download OPA executable
       shell: bash
       run: |
-        python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.operating-system }}
+        python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.os }}
         chmod +x opa_darwin_amd64

--- a/.github/actions/setup-dependencies-macos/action.yml
+++ b/.github/actions/setup-dependencies-macos/action.yml
@@ -1,6 +1,6 @@
 name: Setup Dependencies (macOS)
 inputs:
-  os:
+  operating-system:
     required: true
     default: "macos"
   opa-version:
@@ -30,5 +30,5 @@ runs:
     - name: Download OPA executable
       shell: bash
       run: |
-        python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.os }}
+        python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.operating-system }}
         chmod +x opa_darwin_amd64

--- a/.github/actions/setup-dependencies-windows/action.yml
+++ b/.github/actions/setup-dependencies-windows/action.yml
@@ -1,6 +1,6 @@
 name: Setup Dependencies (Windows)
 inputs:
-  operating-system:
+  os:
     required: true
     default: "windows"
   opa-version:
@@ -18,7 +18,7 @@ runs:
         pip install virtualenv
         python -m venv .venv
         .venv\Scripts\activate
-    
+
     - name: Install dependencies
       shell: powershell
       run: |
@@ -26,16 +26,7 @@ runs:
         pip install -r requirements.txt
         pip install pytest
         pip install selenium
-        pip uninstall -y numpy
-        pip install numpy==1.26.4
-        
-        # Below python v3.9, a lower numpy v1.24.4 is used
-        #$pythonVersion = [version]${{ inputs.python-version }}
-        #if ($pythonVersion -ge [version]"3.8.18") {
-        #  pip uninstall -y numpy
-        #  pip install numpy==1.26.4
-        #} 
-    
+
     - name: Download OPA executable
       shell: powershell
-      run: python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.operating-system }}
+      run: python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.os }}

--- a/.github/actions/setup-dependencies-windows/action.yml
+++ b/.github/actions/setup-dependencies-windows/action.yml
@@ -1,6 +1,6 @@
 name: Setup Dependencies (Windows)
 inputs:
-  os:
+  operating-system:
     required: true
     default: "windows"
   opa-version:
@@ -29,4 +29,4 @@ runs:
 
     - name: Download OPA executable
       shell: powershell
-      run: python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.os }}
+      run: python download_opa.py -v ${{ inputs.opa-version }} -os ${{ inputs.operating-system }}

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Workflow Dispatch Inputs
+        shell: bash
         run: |
           os_input="${{ inputs.os }}"
           pythonversion_input="${{ inputs.python-version }}"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -49,8 +49,8 @@ jobs:
             os_val="['windows-latest', 'macos-latest']"
             pythonversion_val="['3.10']"
           fi
-          echo "os=$os_val" >> $GITHUB_OUTPUT
-          echo "python-version=$pythonversion_val >> $GITHUB_OUTPUT
+          echo "os=$os_val" >> "$GITHUB_OUTPUT"
+          echo "python-version=$pythonversion_val >> "$GITHUB_OUTPUT"
 
   smoke-test:
     needs: configuration

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -32,8 +32,6 @@ on:
         type: string
         default: "0.60.0"
 
-permissions: read-all
-
 jobs:
   configuration:
     runs-on: ubuntu-latest
@@ -75,9 +73,6 @@ jobs:
       GWS_GITHUB_AUTOMATION_CREDS: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
       GWS_SUBJECT_EMAIL: ${{ secrets.GWS_SUBJECT_EMAIL }}
       GWS_DOMAIN: ${{ secrets.GWS_DOMAIN }}
-    permissions:
-      contents: read
-    #environment: Development
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -110,7 +105,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.3
         with: 
           name: "credentials.json"
-          json: $env:GWS_GITHUB_AUTOMATION_CREDS
+          json: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
 
       - name: Run ScubaGoggles and check for correct output
-        run: pytest ./Testing/Functional/SmokeTests/ -vvv --subjectemail="$env:GWS_SUBJECT_EMAIL" --customerdomain="$env:GWS_DOMAIN"
+        run: pytest ./Testing/Functional/SmokeTests/ -vvv --subjectemail="${{ secrets.GWS_SUBJECT_EMAIL }}" --customerdomain="${{ secrets.GWS_DOMAIN }}"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -12,6 +12,7 @@ on:
     #  - ".github/actions/setup-dependencies-macos/action.yml"
     branches:
       - "main"
+      - "*smoketest*"
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -69,7 +69,11 @@ jobs:
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
         python-version: ${{ fromJSON(needs.configuration.outputs.python-version) }}
     runs-on: ${{ matrix.operating-system }}
-    environment: Development
+    env:
+      GWS_GITHUB_AUTOMATION_CREDS: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
+      GWS_SUBJECT_EMAIL: ${{ secrets.GWS_SUBJECT_EMAIL }}
+      GWS_DOMAIN: ${{ secrets.GWS_DOMAIN }}
+    #environment: Development
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -102,7 +106,7 @@ jobs:
         uses: jsdaniell/create-json@v1.2.3
         with: 
           name: "credentials.json"
-          json: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
+          json: $env:GWS_GITHUB_AUTOMATION_CREDS
 
       - name: Run ScubaGoggles and check for correct output
-        run: pytest ./Testing/Functional/SmokeTests/ -s -vvv --subjectemail="${{ secrets.GWS_SUBJECT_EMAIL }}" --customerdomain="${{ secrets.GWS_DOMAIN }}"
+        run: pytest ./Testing/Functional/SmokeTests/ -s -vvv --subjectemail="$env:GWS_SUBJECT_EMAIL" --customerdomain="$env:GWS_DOMAIN"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -38,6 +38,7 @@ jobs:
     outputs:
       os: ${{ steps.variables.outputs.os }}
       python-version: ${{ steps.variables.outputs.python-version }}
+      opa-version: ${{ steps.variables.outputs.opa-version }}
     steps:
       - name: Configure variable outputs
         id: variables
@@ -56,6 +57,7 @@ jobs:
           fi
           echo "os=$os_val" >> "$GITHUB_OUTPUT"
           echo "python-version=$pythonversion_val" >> "$GITHUB_OUTPUT"
+          echo "opa-version=$opaversion_val" >> "$GITHUB_OUTPUT"
 
   smoke-test:
     needs: configuration
@@ -84,7 +86,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies-windows
         with:
           os: "windows"
-          opa-version: ${{ inputs.opa-version }}
+          opa-version: ${{ needs.configuration.outputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       
       - name: Setup Dependencies (macOS)
@@ -92,7 +94,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies-macos
         with:
           os: "macos"
-          opa-version: ${{ inputs.opa-version }}
+          opa-version: ${{ needs.configuration.outputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       
       - name: Setup credentials for service account

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -42,13 +42,17 @@ jobs:
       - name: Configure variable outputs
         id: variables
         run: |
+          # For manual runs
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             os_val="${{ inputs.os }}"
             pythonversion_val="${{ inputs.python-version }}"
+            opaversion_val="${{ inputs.opa-version }}"
+
+          # Default values for other events
           else
-            # Default values for other events
             os_val="['windows-latest', 'macos-latest']"
             pythonversion_val="['3.10']"
+            opaversion_val="0.60.0"
           fi
           echo "os=$os_val" >> "$GITHUB_OUTPUT"
           echo "python-version=$pythonversion_val" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -32,40 +32,39 @@ on:
         default: "0.60.0"
 
 jobs:
-  validate-inputs:
+  configure-inputs:
     runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.set.outputs.os }}
+      python-version: ${{ steps.set.outputs.python-version }}
     steps:
-      - name: Validate Workflow Dispatch Inputs
-        shell: bash
+      - name: Configure inputs 
+        id: set
         run: |
-          os_input="${{ inputs.os }}"
-          pythonversion_input="${{ inputs.python-version }}"
-
-          # Validate the input format with a regular expression
-          if [[ ! "$os_input" =~ ^\[\'.+\'(, \'.+\')*\]$ ]]; then
-            echo "Invalid OS input: $os_input. Expected format: ['os-1', 'os-2', ...]"
-            exit 1
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            os_val="${{ inputs.os }}"
+            pythonversion_val="${{ inputs.python-version }}"
           else
-            echo "OS input is valid: $os_input"
+            # Default values for other events
+            os_val="['windows-latest', 'macos-latest']"
+            pythonversion_val="['3.10']"
           fi
-
-          # Validate the input format with a regular expression
-          if [[ ! "$pythonversion_input" =~ ^\[\'.+\'(, \'.+\')*\]$ ]]; then
-            echo "Invalid Python version input: $pythonversion_input. Expected format: ['3.10', '3.11', ...]"
-            exit 1
-          else
-            echo "Python version input is valid: $pythonversion_input"
-          fi
-          
+          echo "os=$os_val" >> $GITHUB_ENV
+          echo "python-version=$pythonversion_val >> $GITHUB_ENV
+          echo "::set-output name=os::$os_val"
+          echo "::set-output name=os::$pythonversion_val"
+    
   smoke-test:
-    needs: validate-inputs
+    needs: configure-inputs
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.os) }}
+        os: ${{ needs.configure-inputs.outputs.os }}
+        #os: ${{ fromJSON(inputs.os) }}
         # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json,
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
-        python-version: ${{ fromJSON(inputs.python-version) }}
+        #python-version: ${{ fromJSON(inputs.python-version) }}
+        python-version: ${{ needs.configure-inputs.outputs.python-version }}
     runs-on: ${{ matrix.os }}
     environment: Development
     steps:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -105,4 +105,4 @@ jobs:
           json: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
 
       - name: Run ScubaGoggles and check for correct output
-        run: pytest -s -vvv ./Testing/Functional/SmokeTests/ --subjectemail="${{ secrets.GWS_SUBJECT_EMAIL }}" --domain="${{ secrets.GWS_DOMAIN }}"
+        run: pytest ./Testing/Functional/SmokeTests/ -s -vvv --subjectemail="${{ secrets.GWS_SUBJECT_EMAIL }}" --customerdomain="${{ secrets.GWS_DOMAIN }}"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -34,9 +34,6 @@ on:
 jobs:
   configure-inputs:
     runs-on: ubuntu-latest
-    outputs:
-      os: ${{ steps.set.outputs.os }}
-      python-version: ${{ steps.set.outputs.python-version }}
     steps:
       - name: Configure inputs 
         id: set
@@ -52,20 +49,16 @@ jobs:
           fi
           echo "os=$os_val" >> $GITHUB_ENV
           echo "python-version=$pythonversion_val >> $GITHUB_ENV
-          echo "::set-output name=os::$os_val"
-          echo "::set-output name=os::$pythonversion_val"
     
   smoke-test:
     needs: configure-inputs
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ needs.configure-inputs.outputs.os }}
-        #os: ${{ fromJSON(inputs.os) }}
+        os: ${{ fromJSON(env.os) }}
         # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json,
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
-        #python-version: ${{ fromJSON(inputs.python-version) }}
-        python-version: ${{ needs.configure-inputs.outputs.python-version }}
+        python-version: ${{ fromJSON(env.python-version) }}
     runs-on: ${{ matrix.os }}
     environment: Development
     steps:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -40,6 +40,7 @@ jobs:
     steps:
       - name: Configure inputs 
         id: set
+        shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             os_val="${{ inputs.os }}"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -32,6 +32,8 @@ on:
         type: string
         default: "0.60.0"
 
+permissions: read-all
+
 jobs:
   configuration:
     runs-on: ubuntu-latest
@@ -73,6 +75,8 @@ jobs:
       GWS_GITHUB_AUTOMATION_CREDS: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
       GWS_SUBJECT_EMAIL: ${{ secrets.GWS_SUBJECT_EMAIL }}
       GWS_DOMAIN: ${{ secrets.GWS_DOMAIN }}
+    permissions:
+      contents: read
     #environment: Development
     steps:
       - name: Checkout Repository

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -1,7 +1,5 @@
 name: Run Smoke Test 
 on: 
-  workflow_call:
-  workflow_dispatch:
   pull_request:
     types: [opened, reopened]
     branches:
@@ -14,16 +12,34 @@ on:
     #  - ".github/actions/setup-dependencies-macos/action.yml"
     branches:
       - "main"
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      os:
+        description: "Choose operating system(s), format must be an array of strings:"
+        required: true
+        type: string
+        default: "['windows-latest', 'macos-latest']"
+      python-version:
+        description: "Choose python version(s), format must be an array of strings:"
+        required: true
+        type: string
+        default: "['3.10']"
+      opa-version:
+        description: "Choose OPA version"
+        required: true
+        type: string
+        default: "0.59.0"
 
 jobs:
   smoke-test:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest]
+        os: ${{ fromJSON(inputs.os) }}
         # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json,
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
-        python-version: ["3.9", "3.12"] # "3.8 fails with numpy uninstall"
+        python-version: ${{ fromJSON(inputs.python-version) }}
     runs-on: ${{ matrix.os }}
     environment: Development
     steps:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -36,8 +36,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Configure inputs 
-        id: set
-        shell: bash
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             os_val="${{ inputs.os }}"
@@ -49,6 +47,15 @@ jobs:
           fi
           echo "os=$os_val" >> $GITHUB_ENV
           echo "python-version=$pythonversion_val >> $GITHUB_ENV
+
+  test-job:
+    needs: configure-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test
+        run: |
+          echo ${{ env.os }}
+          echo ${{ env.python-version }}
     
   smoke-test:
     needs: configure-inputs

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -4,7 +4,10 @@ on:
     types: [opened, reopened]
     branches:
       - "main"
+  pull_request_review:
+    types: [submitted]
   push:
+    # These paths are primarily for workflow testing purposes
     paths:
       - ".github/workflows/run_smoke_test.yml"
       - ".github/actions/setup-dependencies-windows/action.yml"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -32,10 +32,14 @@ on:
         default: "0.60.0"
 
 jobs:
-  configure-inputs:
+  configuration:
     runs-on: ubuntu-latest
+    outputs:
+      os: ${{ steps.variables.outputs.os }}
+      python-version: ${{ steps.variables.outputs.python-version }}
     steps:
-      - name: Configure inputs 
+      - name: Configure variable outputs
+        id: variables
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             os_val="${{ inputs.os }}"
@@ -45,27 +49,18 @@ jobs:
             os_val="['windows-latest', 'macos-latest']"
             pythonversion_val="['3.10']"
           fi
-          echo "os=$os_val" >> $GITHUB_ENV
-          echo "python-version=$pythonversion_val >> $GITHUB_ENV
+          echo "os=$os_val" >> $GITHUB_OUTPUT
+          echo "python-version=$pythonversion_val >> $GITHUB_OUTPUT
 
-  test-job:
-    needs: configure-inputs
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test
-        run: |
-          echo ${{ env.os }}
-          echo ${{ env.python-version }}
-    
   smoke-test:
-    needs: configure-inputs
+    needs: configuration
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(env.os) }}
+        os: ${{ fromJSON(needs.configuration.outputs.os) }}
         # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json,
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
-        python-version: ${{ fromJSON(env.python-version) }}
+        python-version: ${{ fromJSON(needs.configuration.outputs.python-version) }}
     runs-on: ${{ matrix.os }}
     environment: Development
     steps:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -16,7 +16,7 @@ on:
   workflow_call:
   workflow_dispatch:
     inputs:
-      os:
+      operating-system:
         description: "Choose operating system(s), format must be an array of strings:"
         required: true
         type: string
@@ -36,7 +36,7 @@ jobs:
   configuration:
     runs-on: ubuntu-latest
     outputs:
-      os: ${{ steps.variables.outputs.os }}
+      operating-system: ${{ steps.variables.outputs.operating-system }}
       python-version: ${{ steps.variables.outputs.python-version }}
       opa-version: ${{ steps.variables.outputs.opa-version }}
     steps:
@@ -45,17 +45,17 @@ jobs:
         run: |
           # For manual runs
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            os_val="${{ inputs.os }}"
+            operatingsystem_val="${{ inputs.operating-system }}"
             pythonversion_val="${{ inputs.python-version }}"
             opaversion_val="${{ inputs.opa-version }}"
 
           # Default values for other events
           else
-            os_val="['windows-latest', 'macos-latest']"
+            operatingsystem_val="['windows-latest', 'macos-latest']"
             pythonversion_val="['3.10']"
             opaversion_val="0.60.0"
           fi
-          echo "os=$os_val" >> "$GITHUB_OUTPUT"
+          echo "operating-system=$operatingsystem_val" >> "$GITHUB_OUTPUT"
           echo "python-version=$pythonversion_val" >> "$GITHUB_OUTPUT"
           echo "opa-version=$opaversion_val" >> "$GITHUB_OUTPUT"
 
@@ -64,11 +64,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(needs.configuration.outputs.os) }}
+        operating-system: ${{ fromJSON(needs.configuration.outputs.operating-system) }}
         # See https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json,
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
         python-version: ${{ fromJSON(needs.configuration.outputs.python-version) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.operating-system }}
     environment: Development
     steps:
       - name: Checkout Repository
@@ -82,18 +82,18 @@ jobs:
           cache-dependency-path: "requirements.txt"
       
       - name: Setup Dependencies (Windows)
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.operating-system == 'windows-latest' }}
         uses: ./.github/actions/setup-dependencies-windows
         with:
-          os: "windows"
+          operating-system: "windows"
           opa-version: ${{ needs.configuration.outputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       
       - name: Setup Dependencies (macOS)
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.operating-system == 'macos-latest' }}
         uses: ./.github/actions/setup-dependencies-macos
         with:
-          os: "macos"
+          operating-system: "macos"
           opa-version: ${{ needs.configuration.outputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -6,8 +6,8 @@ on:
       - "main"
   push:
     # Uncomment when testing locally
-    #paths:
-    #  - ".github/workflows/run_smoke_test.yml"
+    paths:
+      - ".github/workflows/run_smoke_test.yml"
     #  - ".github/actions/setup-dependencies-windows/action.yml"
     #  - ".github/actions/setup-dependencies-macos/action.yml"
     branches:
@@ -29,9 +29,33 @@ on:
         description: "Choose OPA version"
         required: true
         type: string
-        default: "0.59.0"
+        default: "0.60.0"
 
 jobs:
+  validate-workflow-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Workflow Dispatch Inputs
+        run: |
+          os_input="${{ inputs.os }}"
+          pythonversion_input="${{ inputs.python-version }}"
+
+          # Validate the input format with a regular expression
+          if [[ ! "$os_input" =~ ^\['[^']+'(, '[^']+')*\]$ ]]; then
+            echo "Invalid OS input: $os_input. Expected format: ['os-1', 'os-2', ...]"
+            exit 1
+          else
+            echo "OS input is valid: $os_input"
+          fi
+
+          # Validate the input format with a regular expression
+          if [[ ! "$pythonversion_input" =~ ^\['[^']+'(, '[^']+')*\]$ ]]; then
+            echo "Invalid Python version input: $pythonversion_input. Expected format: ['3.10', '3.11', ...]"
+            exit 1
+          else
+            echo "Python version input is valid: $pythonversion_input"
+          fi
+          
   smoke-test:
     strategy:
       fail-fast: false
@@ -57,16 +81,16 @@ jobs:
         if: ${{ matrix.os == 'windows-latest' }}
         uses: ./.github/actions/setup-dependencies-windows
         with:
-          operating-system: "windows"
-          opa-version: "0.60.0"
+          os: "windows"
+          opa-version: ${{ inputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       
       - name: Setup Dependencies (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
         uses: ./.github/actions/setup-dependencies-macos
         with:
-          operating-system: "macos"
-          opa-version: "0.60.0"
+          os: "macos"
+          opa-version: ${{ inputs.opa-version }}
           python-version: ${{ matrix.python-version }}
       
       - name: Setup credentials for service account

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -113,4 +113,4 @@ jobs:
           json: $env:GWS_GITHUB_AUTOMATION_CREDS
 
       - name: Run ScubaGoggles and check for correct output
-        run: pytest ./Testing/Functional/SmokeTests/ -s -vvv --subjectemail="$env:GWS_SUBJECT_EMAIL" --customerdomain="$env:GWS_DOMAIN"
+        run: pytest ./Testing/Functional/SmokeTests/ -vvv --subjectemail="$env:GWS_SUBJECT_EMAIL" --customerdomain="$env:GWS_DOMAIN"

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -42,7 +42,7 @@ jobs:
           pythonversion_input="${{ inputs.python-version }}"
 
           # Validate the input format with a regular expression
-          if [[ ! "$os_input" =~ ^\['[^']+'(, '[^']+')*\]$ ]]; then
+          if [[ ! "$os_input" =~ ^\[\'.+\'(, \'.+\')*\]$ ]]; then
             echo "Invalid OS input: $os_input. Expected format: ['os-1', 'os-2', ...]"
             exit 1
           else
@@ -50,7 +50,7 @@ jobs:
           fi
 
           # Validate the input format with a regular expression
-          if [[ ! "$pythonversion_input" =~ ^\['[^']+'(, '[^']+')*\]$ ]]; then
+          if [[ ! "$pythonversion_input" =~ ^\[\'.+\'(, \'.+\')*\]$ ]]; then
             echo "Invalid Python version input: $pythonversion_input. Expected format: ['3.10', '3.11', ...]"
             exit 1
           else

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -5,11 +5,10 @@ on:
     branches:
       - "main"
   push:
-    # Uncomment when testing locally
     paths:
       - ".github/workflows/run_smoke_test.yml"
-    #  - ".github/actions/setup-dependencies-windows/action.yml"
-    #  - ".github/actions/setup-dependencies-macos/action.yml"
+      - ".github/actions/setup-dependencies-windows/action.yml"
+      - ".github/actions/setup-dependencies-macos/action.yml"
     branches:
       - "main"
       - "*smoketest*"
@@ -69,10 +68,6 @@ jobs:
         # ctrl + f and search "python-3.<minor>.<patch>-<darwin-arm64/win32/linux>" for supported versions
         python-version: ${{ fromJSON(needs.configuration.outputs.python-version) }}
     runs-on: ${{ matrix.operating-system }}
-    env:
-      GWS_GITHUB_AUTOMATION_CREDS: ${{ secrets.GWS_GITHUB_AUTOMATION_CREDS }}
-      GWS_SUBJECT_EMAIL: ${{ secrets.GWS_SUBJECT_EMAIL }}
-      GWS_DOMAIN: ${{ secrets.GWS_DOMAIN }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -32,7 +32,7 @@ on:
         default: "0.60.0"
 
 jobs:
-  validate-workflow-inputs:
+  validate-inputs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate Workflow Dispatch Inputs
@@ -57,6 +57,7 @@ jobs:
           fi
           
   smoke-test:
+    needs: validate-inputs
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -50,7 +50,7 @@ jobs:
             pythonversion_val="['3.10']"
           fi
           echo "os=$os_val" >> "$GITHUB_OUTPUT"
-          echo "python-version=$pythonversion_val >> "$GITHUB_OUTPUT"
+          echo "python-version=$pythonversion_val" >> "$GITHUB_OUTPUT"
 
   smoke-test:
     needs: configuration

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -11,16 +11,16 @@ This README outlines the ScubaGoggles software test automation and its usage. Th
   - [Smoke Testing Classes and Methods](#smoke-testing-classes-and-methods)
   - [Automated workflow via GitHub Actions](#automated-workflow-via-github-actions)
 - [Functional Smoke Testing Usage](#functional-smoke-testing-usage)
-  - [Running on a Local Development Environment](#running-on-a-local-development-environment)
+  - [Running in a Local Development Environment](#running-in-a-local-development-environment)
   - [Running Remotely via GitHub Actions](#running-remotely-via-github-actions)
 
 ## Smoke Testing Prerequisites ## 
 Running the ScubaGoggles functional smoke tests requires a Windows, MacOS, or Linux computer or VM. The development environment should have Python v3.10.x installed at a minimum ([refer to our installing Python dependencies documentation if its not already installed](https://github.com/cisagov/ScubaGoggles/blob/main/docs/installation/DownloadAndInstall.md#installing-python-dependencies)), Pytest, and Selenium installed locally.
 
 ### Pytest and Selenium ### 
-Pytest is a Python testing framework which is commonly used for unit, integration, and functional testing. [Pytest Get Started](https://docs.pytest.org/en/stable/getting-started.html)
+Pytest is a Python testing framework which is commonly used for unit, integration, and functional testing. ([Pytest Get Started](https://docs.pytest.org/en/stable/getting-started.html))
 
-Selenium supports automation of all the major browsers in the market through the use of WebDriver. [Selenium Get Started](https://www.selenium.dev/documentation/webdriver/getting_started/)
+Selenium supports automation of all the major browsers in the market through the use of WebDriver. ([Selenium Get Started](https://www.selenium.dev/documentation/webdriver/getting_started/))
 
 To install Pytest and Selenium on your development environment, open a new terminal session and run the following command:
 
@@ -59,14 +59,15 @@ The automated workflow for running the functional smoke tests ([/.github/workflo
 ## Functional Smoke Testing Usage ## 
 After completing all of the prerequisite steps, the functional smoke tests can be run on a local development environment or remotely via GitHub Actions.
 
-### Running on a Local Development Environment ### 
-Ensure that you have correctly setup a Google service account and that the `credentials.json` stored at the root directory of the ScubaGoggles project is up to date. If you haven't already, please refer back to the [prerequisite step](/Google-Service-Account) on how to get setup before proceeding. 
+### Running in a Local Development Environment ### 
+> [!IMPORTANT]
+> Ensure that you have correctly setup a Google service account and that the `credentials.json` stored at the root directory of the ScubaGoggles project is up to date. If you haven't already, please refer back to the [prerequisite step on Google Service Accounts](#google-service-account) for how to get setup before proceeding. 
 
 The following arguments are required when running the functional smoke tests:
-- `subjectemail`: user@domain.com (the email used to authenticate with GWS, must have necessary administrator permissions)
-- `customerdomain`: domain.com (the domain that ScubaGoggles is run against)
+- `--subjectemail="user@domain.com"` (the email used to authenticate with GWS, must have necessary administrator permissions)
+- `--customerdomain="domain.com"` (the domain that ScubaGoggles is run against)
 
-Run the following command to execute the functional smoke tests:
+Replace `user@domain.com` with your email and `domain.com` with your domain, then run the following command to execute the functional smoke tests:
 ```
 pytest ./Testing/Functional/SmokeTests/ -vvv --subjectemail="user@domain.com" --customerdomain="domain.com"
 ```
@@ -78,15 +79,15 @@ Common Pytest parameters and their use cases:
 - `-s` (disables output capturing allowing print() statements and logs to be shown in the console)
 - `-k` (run tests that match a keyword)
 
-    Example:
+    Example (only runs test_scubagoggles_output, deselects the rest):
     ```
     pytest ./Testing/Functional/SmokeTests/ -vvv -k test_scubagoggles_output --subjectemail="user@domain.com" --customerdomain="domain.com"
     ```
 
-- `--tb=short`, `tb=long`, or `tb=none` (provide either brief, full, or suppress the traceback output for failed tests)
+- `--tb=short`, `tb=long`, or `tb=no` (provide either brief, full, or suppress the traceback output for failed tests)
 - `-q` (reduces output to show only minimal information)
 
-Run `pytest -h` for a full list of CLI options, or [learn more about Pytest usage](https://docs.pytest.org/en/7.1.x/how-to/usage.html)
+Run `pytest -h` for a full list of CLI options, or [learn more about Pytest usage here.](https://docs.pytest.org/en/7.1.x/how-to/usage.html)
 
 ### Running Remotely via GitHub Actions ### 
 Go to the [run_smoke_test.yml workflow](https://github.com/cisagov/ScubaGoggles/actions/workflows/run_smoke_test.yml) in the GitHub Actions tab.

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -44,9 +44,9 @@ ScubaGoggles functional smoke testing has two main components: the smoke testing
 
 ### Smoke Testing Classes and Methods ### 
 The smoke testing orchestrator ([/Testing/Functional/SmokeTests/smoke_test.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py)) executes each test declared inside the `SmokeTest` class. The tests currently cover:
-- if the `scubagoggles gws` command generates correct output for all baselines
+- if the `scubagoggles gws` command generates valid output for all baselines
 - if ScubaResults.json contains API errors or exceptions
--  if the generated baseline reports are correct, i.e. BaselineReports.html, CalendarReport.html, ChatReport.html
+- if the generated baseline reports, i.e. BaselineReports.html, CalendarReport.html, ChatReport.html, etc., contain valid content and all links redirect accordingly 
 
 The smoke testing utils ([/Testing/Functional/SmokeTests/smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py)) stores helper methods which perform various operations.
 

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -90,18 +90,17 @@ Common Pytest parameters and their use cases:
 Run `pytest -h` for a full list of CLI options, or [learn more about Pytest usage here.](https://docs.pytest.org/en/7.1.x/how-to/usage.html)
 
 ### Running Remotely via GitHub Actions ### 
-Go to the [run_smoke_test.yml workflow](https://github.com/cisagov/ScubaGoggles/actions/workflows/run_smoke_test.yml) in the GitHub Actions tab.
+Go to the [run_smoke_test.yml workflow](https://github.com/cisagov/ScubaGoggles/actions/workflows/run_smoke_test.yml) in the GitHub Actions tab, then click the "Run workflow" dropdown button. 
 
-![Screenshot (216)](https://github.com/user-attachments/assets/adb1c656-7065-4031-850c-0dc1402e3bda)
-
-The default values are the following: 
+The default values are the following:
+- ref branch: `main` but can be set to any branch
 - operating system: `['windows-latest', 'macos-latest']` ([list of supported GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))
 - python version: `['3.10']`
 - opa version: "0.60.0"
 
-![Screenshot (214)](https://github.com/user-attachments/assets/9ce1f00e-24e5-4e06-b3ad-aad7b7bc16c7)
+![Screenshot (226)](https://github.com/user-attachments/assets/6f25b7a9-3981-4866-a413-93df4bae1130)
 
-Feel free to play around with the inputs. The workflow will create a matrix strategy for each combination. For example, passing `['windows-latest', 'macos-latest']`, `['3.10', '3.11', 3.12']`, and OPA version `0.60.0` will create the following:
+Feel free to play around with the inputs then click the "Run workflow" button when ready. The workflow will create a matrix strategy for each combination. For example, passing `['windows-latest', 'macos-latest']`, `['3.10', '3.11', 3.12']`, and OPA version `0.60.0` will create the following:
 
 ![Screenshot (218)](https://github.com/user-attachments/assets/212b4e4b-d552-4dc9-a3f6-7f0e29accc4b)
 

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -22,13 +22,51 @@ pip install pytest selenium
 > [!NOTE]
 > The functional smoke tests use Chrome as its WebDriver when running Selenium tests. If you don't already have the Google Chrome web browser installed, [setup ChromeDriver here](https://developer.chrome.com/docs/chromedriver/get-started).
 
+### Google Service Account ###
+The ScubaGoggles functional smoke tests must be executed with a service account. [Refer to our documentation here on how to get setup.](https://github.com/cisagov/ScubaGoggles/blob/main/docs/authentication/ServiceAccount.md#using-a-service-account)
+
+A `credentials.json` file is required at the root directory of the ScubaGoggles project if running the functional smoke tests in a local development environment.
+
+Take note of the `subjectemail`, the email used to authenticate with GWS that has necessary administrator permissions, and the GWS `customerdomain` that ScubaGoggles is run against. Both credentials are required in a later step.
+
 ## Functional Smoke Testing Structure ##
 ScubaGoggles functional smoke testing has two main components: the smoke testing orchestrator and the automated workflow which is run via GitHub Actions.
 
-### Smoke testing orchestrator ### 
+### Smoke testing directory structure ### 
 The smoke testing orchestrator ([/Testing/Functional/SmokeTests/smoke_test.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py)) executes each test declared inside the `SmokeTest` class. The tests currently cover:
 - if the `scubagoggles gws` command generates correct output for all baselines
 - if ScubaResults.json contains API errors or exceptions
 -  if the generated baseline reports are correct, i.e. BaselineReports.html, CalendarReport.html, ChatReport.html
 
+The smoke testing utils ([/Testing/Functional/SmokeTests/smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py)) stores helper methods which perform various operations.
+
+The Selenium Browser class ([/Testing/Functional/SmokeTests/selenium_browser.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/selenium_browser.py)) encapsulates the setup, usage, and teardown of Selenium WebDriver instances.
+
+The Pytest configuration methods ([/Testing/Functional/SmokeTests/conftest.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/conftest.py)) declare various Pytest fixtures, allowing for the use of CLI arguments when invoking the Pytest command.  
+
 ### Automated workflow via GitHub Actions ### 
+The automated workflow for running the functional smoke tests ([/.github/workflows/run_smoke_test.yml](https://github.com/cisagov/ScubaGoggles/blob/main/.github/workflows/run_smoke_test.yml)) is triggered on `push` events to the main branch, `pull_request` events when a pull request is opened/reopened, and manually with customer user input via workflow_dispatch.
+
+## Functional Smoke Testing Usage ## 
+After completing all of the prerequisite steps, the functional smoke tests can be run on a local development environment or remotely via GitHub Actions.
+
+### Running on a local development environment ### 
+Ensure that you have correctly setup a Google service account and that the `credentials.json` stored at the root directory of the ScubaGoggles project is up to date. If you haven't already, please refer back to the [prerequisite step](/Google-Service-Account) on how to get setup before proceeding. 
+
+The following arguments are required when running the functional smoke tests:
+- `subjectemail`: user@domain.com (the email used to authenticate with GWS, must have necessary administrator permissions)
+- `customerdomain`: domain.com (the domain that ScubaGoggles is run against)
+
+Run the following command to execute the functional smoke tests:
+```
+pytest -vvv ./Testing/Functional/SmokeTests/ --subjectemail="user@domain.com" --customerdomain="domain.com"
+```
+
+Common Pytest parameters and their use cases:
+- `-v` or `--verbose` (shows individual test names and results)
+- `-vv` (increases verbosity further, shows detailed output about each test)
+- `-vvv` (shows even more detailed output and debug-level information)
+- `-s` (disables output capturing allowing print() statements and logs to be shown in the console)
+
+### Running remotely via GitHub Actions ### 
+

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -13,7 +13,7 @@ This README outlines the ScubaGoggles software test automation structure and its
 - [Functional Smoke Testing Usage](#functional-smoke-testing-usage)
   - [Running in a Local Development Environment](#running-in-a-local-development-environment)
   - [Running Remotely via GitHub Actions](#running-remotely-via-github-actions)
-- [Adding New Functional Tests](#adding-new-functional-tests)
+- [Adding New Tests](#adding-new-tests)
 
 ## Smoke Testing Prerequisites ## 
 Running the ScubaGoggles functional smoke tests requires a Windows, MacOS, or Linux computer or VM. The development environment should have Python v3.10.x installed at a minimum ([refer to our installing Python dependencies documentation if its not already installed](https://github.com/cisagov/ScubaGoggles/blob/main/docs/installation/DownloadAndInstall.md#installing-python-dependencies)), Pytest, and Selenium installed locally.
@@ -30,17 +30,17 @@ pip install pytest selenium
 ```
 
 > [!NOTE]
-> The functional smoke tests use Chrome as its WebDriver when running Selenium tests. If you don't already have the Google Chrome web browser installed, [setup ChromeDriver here](https://developer.chrome.com/docs/chromedriver/get-started).
+> The functional smoke tests use Chrome as its WebDriver when running Selenium tests. [Setup ChromeDriver](https://developer.chrome.com/docs/chromedriver/get-started) if you don't already have the Google Chrome web browser installed.
 
 ### Google Service Account ###
-The ScubaGoggles functional smoke tests must be executed with a service account. [Refer to our documentation here on how to get setup.](https://github.com/cisagov/ScubaGoggles/blob/main/docs/authentication/ServiceAccount.md#using-a-service-account)
+The ScubaGoggles functional smoke tests must be executed with a service account. [Refer to our service account documentation on how to get setup.](https://github.com/cisagov/ScubaGoggles/blob/main/docs/authentication/ServiceAccount.md#using-a-service-account)
 
 A `credentials.json` file is required at the root directory of the ScubaGoggles project if running the functional smoke tests in a local development environment.
 
 Take note of the `subjectemail`, the email used to authenticate with GWS that has necessary administrator permissions, and the GWS `customerdomain` that ScubaGoggles is run against. Both credentials are required in a later step.
 
 ## Functional Smoke Testing Structure ##
-ScubaGoggles functional smoke testing has two main components: the smoke testing orchestrator and the automated workflow which is run via GitHub Actions.
+ScubaGoggles functional smoke testing has two main components: the smoke testing orchestrator and the automated workflow run via GitHub Actions.
 
 ### Smoke Testing Classes and Methods ### 
 The smoke testing orchestrator ([/Testing/Functional/SmokeTests/smoke_test.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py)) executes each test declared inside the `SmokeTest` class. The tests currently cover:
@@ -55,14 +55,14 @@ The Selenium Browser class ([/Testing/Functional/SmokeTests/selenium_browser.py]
 The Pytest configuration methods ([/Testing/Functional/SmokeTests/conftest.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/conftest.py)) declare various Pytest fixtures, allowing for the use of CLI arguments when invoking the Pytest command.  
 
 ### Automated Workflow via GitHub Actions ### 
-The automated workflow for running the functional smoke tests ([/.github/workflows/run_smoke_test.yml](https://github.com/cisagov/ScubaGoggles/blob/main/.github/workflows/run_smoke_test.yml)) is triggered on `push` events to the main branch, `pull_request` events when a pull request is opened/reopened, and manually with customer user input via workflow_dispatch.
+The automated workflow for running the functional smoke tests ([/.github/workflows/run_smoke_test.yml](https://github.com/cisagov/ScubaGoggles/blob/main/.github/workflows/run_smoke_test.yml)) is triggered on `push` events to the main branch, `pull_request` events when a pull request is opened/reopened/reviewed, and manually with custom user input via workflow_dispatch.
 
 ## Functional Smoke Testing Usage ## 
-After completing all of the prerequisite steps, the functional smoke tests can be run on a local development environment or remotely via GitHub Actions.
+After completing all of the prerequisite steps, the functional smoke tests can be run in a local development environment or remotely via GitHub Actions.
 
 ### Running in a Local Development Environment ### 
 > [!IMPORTANT]
-> Ensure that you have correctly setup a Google service account and that the `credentials.json` stored at the root directory of the ScubaGoggles project is up to date. If you haven't already, please refer back to the [prerequisite step on Google Service Accounts](#google-service-account) for how to get setup before proceeding. 
+> Ensure that you have correctly setup a Google service account and that the `credentials.json` stored at the root directory of the ScubaGoggles project is up to date. If you haven't already, please refer back to the [prerequisite step on Google Service Accounts](#google-service-account) for how to setup before proceeding. 
 
 The following arguments are required when running the functional smoke tests:
 - `--subjectemail="user@domain.com"` (the email used to authenticate with GWS, must have necessary administrator permissions)
@@ -88,7 +88,7 @@ Common Pytest parameters and their use cases:
 - `--tb=short`, `tb=long`, or `tb=no` (provide either brief, full, or suppress the traceback output for failed tests)
 - `-q` (reduces output to show only minimal information)
 
-Run `pytest -h` for a full list of CLI options, or [learn more about Pytest usage here.](https://docs.pytest.org/en/7.1.x/how-to/usage.html)
+Run `pytest -h` for a full list of CLI options or [learn more about Pytest usage here.](https://docs.pytest.org/en/7.1.x/how-to/usage.html)
 
 ### Running Remotely via GitHub Actions ### 
 Go to the [run_smoke_test.yml workflow](https://github.com/cisagov/ScubaGoggles/actions/workflows/run_smoke_test.yml) in the GitHub Actions tab, then click the "Run workflow" dropdown button. 
@@ -111,8 +111,8 @@ Some factors to consider:
 - Python versions <3.10.x are not supported and will cause the smoke test workflow to fail. 
 - [Due to the lack of an array input type from GitHub](https://github.com/orgs/community/discussions/11692), the required format is an array of strings for the operating system and python version inputs. This is something to capture as a future todo once arrays are available.
 
-## Adding New Functional Tests ##
-A new functional smoke test should be added as a method in the [SmokeTest class](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py). Helper methods should be stored in [smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py).
+## Adding New Tests ##
+A new smoke test should be added as a method in the [SmokeTest class](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py). Helper methods should be added in [smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py).
 
 Below is an example that tests the `scubagoggles gws` command:
 

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -1,0 +1,34 @@
+# ScubaGoggles Functional Smoke Testing Automation
+The ScubaGoggles repository consists of an automation suite to help test the functionality of the ScubaGoggles tool itself. The test automation is geared towards contributors who want to execute the functional smoke testing orchestrator as part of their development/testing activity.
+
+This README outlines the ScubaGoggles software test automation and its usage. The document also contains instructions for adding new functional tests to existing automation suite.
+
+## Table of Contents 
+
+## Smoke Testing Prerequisites ## 
+Running the ScubaGoggles functional smoke tests requires a Windows, MacOS, or Linux computer or VM. The development environment should have Python v3.10.x installed at a minimum ([refer to our installing Python dependencies documentation if its not already installed](https://github.com/cisagov/ScubaGoggles/blob/main/docs/installation/DownloadAndInstall.md#installing-python-dependencies)), Pytest, and Selenium installed locally.
+
+### Pytest and Selenium ### 
+Pytest is a Python testing framework which is commonly used for unit, integration, and functional testing. [Pytest Get Started](https://docs.pytest.org/en/stable/getting-started.html)
+
+Selenium supports automation of all the major browsers in the market through the use of WebDriver. [Selenium Get Started](https://www.selenium.dev/documentation/webdriver/getting_started/)
+
+To install Pytest and Selenium on your development environment, open a new terminal session and run the following command:
+
+```
+pip install pytest selenium
+```
+
+> [!NOTE]
+> The functional smoke tests use Chrome as its WebDriver when running Selenium tests. If you don't already have the Google Chrome web browser installed, [setup ChromeDriver here](https://developer.chrome.com/docs/chromedriver/get-started).
+
+## Functional Smoke Testing Structure ##
+ScubaGoggles functional smoke testing has two main components: the smoke testing orchestrator and the automated workflow which is run via GitHub Actions.
+
+### Smoke testing orchestrator ### 
+The smoke testing orchestrator ([/Testing/Functional/SmokeTests/smoke_test.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py)) executes each test declared inside the `SmokeTest` class. The tests currently cover:
+- if the `scubagoggles gws` command generates correct output for all baselines
+- if ScubaResults.json contains API errors or exceptions
+-  if the generated baseline reports are correct, i.e. BaselineReports.html, CalendarReport.html, ChatReport.html
+
+### Automated workflow via GitHub Actions ### 

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -1,7 +1,7 @@
 # ScubaGoggles Functional Smoke Testing Automation
 The ScubaGoggles repository consists of an automation suite to help test the functionality of the ScubaGoggles tool itself. The test automation is geared towards contributors who want to execute the functional smoke testing orchestrator as part of their development/testing activity.
 
-This README outlines the ScubaGoggles software test automation and its usage. The document also contains instructions for adding new functional tests to existing automation suite.
+This README outlines the ScubaGoggles software test automation structure and its usage. The document also contains instructions for adding new tests to the existing automation suite if necessary.
 
 ## Table of Contents
 - [Smoke Testing Prerequisites](#smoke-testing-prerequisites)
@@ -13,6 +13,7 @@ This README outlines the ScubaGoggles software test automation and its usage. Th
 - [Functional Smoke Testing Usage](#functional-smoke-testing-usage)
   - [Running in a Local Development Environment](#running-in-a-local-development-environment)
   - [Running Remotely via GitHub Actions](#running-remotely-via-github-actions)
+- [Adding New Functional Tests](#adding-new-functional-tests)
 
 ## Smoke Testing Prerequisites ## 
 Running the ScubaGoggles functional smoke tests requires a Windows, MacOS, or Linux computer or VM. The development environment should have Python v3.10.x installed at a minimum ([refer to our installing Python dependencies documentation if its not already installed](https://github.com/cisagov/ScubaGoggles/blob/main/docs/installation/DownloadAndInstall.md#installing-python-dependencies)), Pytest, and Selenium installed locally.
@@ -108,4 +109,35 @@ Some factors to consider:
 - Each input is required so an empty string will fail validation. `[]`, `['']`, `['', ]` may also cause the workflow to error out, although this is expected behavior.
 - `ubuntu-latest` has not been tested as a value for operating system. Support can be added for this, although its dependent on if this is something we want to test for ScubaGoggles as a whole. 
 - Python versions <3.10.x are not supported and will cause the smoke test workflow to fail. 
-- [Due to the lack of an array input type from GitHub](https://github.com/orgs/community/discussions/11692), the required format is an array of strings for the operating system and python version inputs. This is something to capture as a future todo once arrays are available. 
+- [Due to the lack of an array input type from GitHub](https://github.com/orgs/community/discussions/11692), the required format is an array of strings for the operating system and python version inputs. This is something to capture as a future todo once arrays are available.
+
+## Adding New Functional Tests ##
+A new functional smoke test should be added as a method in the [SmokeTest class](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py). Helper methods should be stored in [smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py).
+
+Below is an example that runs the `scubagoggles gws` command then performs some conditional check with Selenium:
+
+```
+class SmokeTest:
+  ...
+
+  def test_scubagoggles_execution(self, browser, subjectemail):
+    """
+    Test if the `scubagoggles gws` command succeeds or fails.
+        
+    Args:
+      browser: A Selenium WebDriver instance
+      subjectemail: The email address of an admin user who created the service account
+    """
+    try:
+      command: str = f"scubagoggles gws --subjectemail {subjectemail} --quiet"
+      result = subprocess.run(command, shell=True, check=True, capture_output=True)
+
+      if result.returncode != 0:
+        print(f"Scubagoggles execution failed with error:\n{result.stderr}")
+        assert False
+      else:
+        print("Scubagoggles execution succeeded")
+        print(f"Output:\n{result.stdout}")
+    except Exception as e:
+      pytest.fail(f"An error occurred, {e}")
+```

--- a/Testing/Functional/SmokeTests/README.md
+++ b/Testing/Functional/SmokeTests/README.md
@@ -114,18 +114,17 @@ Some factors to consider:
 ## Adding New Functional Tests ##
 A new functional smoke test should be added as a method in the [SmokeTest class](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test.py). Helper methods should be stored in [smoke_test_utils.py](https://github.com/cisagov/ScubaGoggles/blob/main/Testing/Functional/SmokeTests/smoke_test_utils.py).
 
-Below is an example that runs the `scubagoggles gws` command then performs some conditional check with Selenium:
+Below is an example that tests the `scubagoggles gws` command:
 
 ```
 class SmokeTest:
   ...
 
-  def test_scubagoggles_execution(self, browser, subjectemail):
+  def test_scubagoggles_execution(self, subjectemail):
     """
     Test if the `scubagoggles gws` command succeeds or fails.
         
     Args:
-      browser: A Selenium WebDriver instance
       subjectemail: The email address of an admin user who created the service account
     """
     try:

--- a/Testing/Functional/SmokeTests/selenium_browser.py
+++ b/Testing/Functional/SmokeTests/selenium_browser.py
@@ -13,6 +13,7 @@ class Browser:
     def __init__(self):
         chrome_options = Options()
         chrome_options.add_argument("--headless")
+        chrome_options.add_argument("--window-size=1200,800")
         chrome_options.add_argument("--no-sandbox")
         chrome_options.add_argument("--disable-dev-shm-usage")
 

--- a/Testing/Functional/SmokeTests/smoke_test.py
+++ b/Testing/Functional/SmokeTests/smoke_test.py
@@ -57,7 +57,7 @@ class SmokeTest:
         except (ValueError, Exception) as e:
             pytest.fail(f"An error occurred, {e}")
 
-    def test_scubagoggles_report(self, browser, domain):
+    def test_scubagoggles_report(self, browser, customerdomain):
         """
         Test if the generated baseline reports are correct,
         i.e. BaselineReports.html, CalendarReport.html, ChatReport.html
@@ -66,7 +66,7 @@ class SmokeTest:
             output_path: str = get_output_path()
             report_path: str = prepend_file_protocol(os.path.join(output_path, BASELINE_REPORTS))
             browser.get(report_path)
-            run_selenium(browser, domain)
+            run_selenium(browser, customerdomain)
         except (ValueError, AssertionError, Exception) as e:
             browser.quit()
             pytest.fail(f"An error occurred, {e}")

--- a/Testing/Functional/SmokeTests/smoke_test_utils.py
+++ b/Testing/Functional/SmokeTests/smoke_test_utils.py
@@ -125,13 +125,13 @@ def verify_scubaresults(jsonfile):
         if summary["Errors"] != 0:
             raise ValueError(f"{product} contains errors in the report")
 
-def run_selenium(browser, domain):
+def run_selenium(browser, customerdomain):
     """
     Run Selenium tests against the generated reports.
 
     Args:
         browser: A Selenium WebDriver instance
-        domain: The user's domain
+        customerdomain: The customer domain
     """
     verify_navigation_links(browser)
     h1 = browser.find_element(By.TAG_NAME, "h1").text
@@ -149,9 +149,9 @@ def run_selenium(browser, domain):
     if len(reports_table) == 10:
         for i in range(len(reports_table)):
 
-            # Check if domain is present in agency table
+            # Check if customerdomain is present in agency table
             # Skip tool version if assessing the parent report
-            verify_tenant_table(browser, domain, True)
+            verify_tenant_table(browser, customerdomain, True)
 
             reports_table = get_reports_table(browser)[i]
             baseline_report = reports_table.find_elements(By.TAG_NAME, "td")[0]
@@ -169,8 +169,8 @@ def run_selenium(browser, domain):
             h1 = browser.find_element(By.TAG_NAME, "h1").text
             assert h1 == products[product]["title"]
 
-            # Check if domain and tool version are present in individual report
-            verify_tenant_table(browser, domain, False)
+            # Check if customerdomain and tool version are present in individual report
+            verify_tenant_table(browser, customerdomain, False)
 
             policy_tables = browser.find_elements(By.TAG_NAME, "table")
             for table in policy_tables[1:]:
@@ -239,14 +239,14 @@ def get_reports_table(browser):
         .find_elements(By.TAG_NAME, "tr")
     )
 
-def verify_tenant_table(browser, domain, parent):
+def verify_tenant_table(browser, customerdomain, parent):
     """
     Get the tenant table rows elements from the DOM.
-    (Table at the top of each report with user domain, baseline/tool version)
+    (Table at the top of each report with customer domain, baseline/tool version)
 
     Args:
         browser: A Selenium WebDriver instance
-        domain: The user's domain
+        customerdomain: The customer domain
         parent: boolean to determine parent/individual reports
     """
     tenant_table_rows = (
@@ -255,8 +255,8 @@ def verify_tenant_table(browser, domain, parent):
         .find_elements(By.TAG_NAME, "tr")
     )
     assert len(tenant_table_rows) == 2
-    customer_domain = tenant_table_rows[1].find_elements(By.TAG_NAME, "td")[0].text
-    assert customer_domain == domain
+    domain = tenant_table_rows[1].find_elements(By.TAG_NAME, "td")[0].text
+    assert domain == customerdomain
 
     if not parent:
         # Check for correct tool version, e.g. 0.2.0

--- a/Testing/Functional/SmokeTests/smoke_test_utils.py
+++ b/Testing/Functional/SmokeTests/smoke_test_utils.py
@@ -11,7 +11,7 @@ from scubagoggles.orchestrator import Orchestrator
 from scubagoggles.utils import get_package_version
 
 OUTPUT_DIRECTORY = "GWSBaselineConformance"
-BASELINE_REPORT_H1 = "SCuBA GWS Security Baseline Conformance Reports"
+BASELINE_REPORT_H1 = "SCuBA GWS Secure Configuration Baseline Reports"
 CISA_GOV_URL = "https://www.cisa.gov/scuba"
 SCUBAGOGGLES_BASELINES_URL = "https://github.com/cisagov/ScubaGoggles/tree/main/baselines"
 

--- a/Testing/Functional/conftest.py
+++ b/Testing/Functional/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
             parser: An instance of "argparse.ArgumentParser"
     """
     parser.addoption("--subjectemail", action="store")
-    parser.addoption("--domain", action="store")
+    parser.addoption("--customerdomain", action="store")
 
 @pytest.fixture
 def subjectemail(pytestconfig):
@@ -26,14 +26,14 @@ def subjectemail(pytestconfig):
     return pytestconfig.getoption("subjectemail")
 
 @pytest.fixture
-def domain(pytestconfig):
+def customerdomain(pytestconfig):
     """
-        Setup code that shares the "domain" parameter across tests.
+        Setup code that shares the "customerdomain" parameter across tests.
 
         Args:
             pytestconfig: Provides access to the "Config" object for a current test session
     """
-    return pytestconfig.getoption("domain")
+    return pytestconfig.getoption("customerdomain")
 
 @pytest.fixture
 def browser():


### PR DESCRIPTION
## 🗣 Description ##

This PR expands on the smoke testing workflow to be more dynamic, such that it can be triggered on push and pull_request events and manually with custom user input.

Made a couple other quality of life improvements to the workflow as well:
- removed `environment: Development` key/value from the workflow which removes the `x user deployed to Development 1 hour ago -- with GitHub Actions` messages that cluttered pull request timelines.
- the "SCuBA GWS Secure Configuration Baseline Reports" update in BaselineReports.html broke the selenium test since it was checking for the old format.

### 💭 Motivation and context

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

The smoke testing workflow is currently hardcoded to run against the following operating systems, python/OPA versions: `['windows-latest', 'macos-latest']`, `['3.9', '3.12']`, and v0.59.0. This is because the `workflow_dispatch` event for manual runs is only available after a workflow is committed to the main branch. 

Closes #340 
Closes #341 
Closes #415

## 🧪 Testing

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Go to the [run_smoke_test.yml workflow](https://github.com/cisagov/ScubaGoggles/actions/workflows/run_smoke_test.yml) in the GitHub Actions tab. Click the "Run workflow" button then set `340-smoketest-add-user-input` as the ref branch.

![Screenshot (216)](https://github.com/user-attachments/assets/adb1c656-7065-4031-850c-0dc1402e3bda)

The default values are the following: 
- operating system: `['windows-latest', 'macos-latest']` ([list of supported GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))
- python version: `['3.10']`
- opa version: "0.60.0"

![Screenshot (214)](https://github.com/user-attachments/assets/9ce1f00e-24e5-4e06-b3ad-aad7b7bc16c7)

Feel free to play around with the inputs then click the "Run workflow" button when ready. The workflow will create a matrix strategy for each combination. For example, passing `['windows-latest', 'macos-latest']`, `['3.10', '3.11', 3.12']`, and OPA version `0.60.0` will create the following:

![Screenshot (218)](https://github.com/user-attachments/assets/212b4e4b-d552-4dc9-a3f6-7f0e29accc4b)

Some factors to consider:
- Each input is required so an empty string will fail validation. `[]`, `['']`, `['', ]` may also cause the workflow to error out, although this is expected behavior.
- `ubuntu-latest` has not been tested as a value for operating system. Support can be added for this, although its dependent on if this is something we want to test for ScubaGoggles as a whole. 
- Python versions <3.10.x are not supported and will cause the smoke test workflow to fail. 
- [Due to the lack of an array input type from GitHub](https://github.com/orgs/community/discussions/11692), the required format is an array of strings for the operating system and python version inputs. This is something to capture as a future todo once arrays are available. 

[The workflow runs successfully when testing push events with default values.](https://github.com/cisagov/ScubaGoggles/actions/runs/10927021004)
[The workflow runs successfully when testing pull_request opened events with default values.](https://github.com/cisagov/ScubaGoggles/actions/runs/10913759349 )

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.