### PR TITLE
Add config file support for control omission

### DIFF
--- a/docs/usage/Config.md
+++ b/docs/usage/Config.md
@@ -27,11 +27,11 @@ In some cases, it may be appropriate to omit specific policies from ScubaGoggles
 - When a policy is implemented by a third-party service that ScubaGoggles does not audit
 - When a policy is not applicable to your organization (e.g., policy GWS.GMAIL.4.3v0.3 is only applicable to federal, executive branch, departments and agencies)
 
-The `OmitPolicy` top-level key, shown in this [example ScubaGoggles configuration file](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
+The `omitpolicy` top-level key, shown in this [example ScubaGoggles configuration file](/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
 
 For each omitted policy, the config file allows you to indicate the following:
-- `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
-- `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
+- `rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
+- `expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
 
 
 ## Navigation

--- a/docs/usage/Config.md
+++ b/docs/usage/Config.md
@@ -24,13 +24,13 @@ scubagoggles gws --config basic_config.yaml -b gmail chat
 ## Omit Policies
 
 In some cases, it may be appropriate to omit specific policies from ScubaGoggles evaluation. For example:
-- When a policy is implemented by a third-party service that ScubaGoggles does not audit
-- When a policy is not applicable to your organization (e.g., policy GWS.GMAIL.4.3v0.3 is only applicable to federal, executive branch, departments and agencies)
+- When a policy is implemented by a third-party service that ScubaGoggles does not audit.
+- When a policy is not applicable to your organization (e.g., policy GWS.GMAIL.4.3v0.3, which is only applicable to federal, executive branch, departments and agencies).
 
-The `omitpolicy` top-level key, shown in this [example ScubaGoggles configuration file](/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
+The `omitpolicy` top-level key, shown in this [example ScubaGoggles configuration file](/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGoggles report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
 
 For each omitted policy, the config file allows you to indicate the following:
-- `rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
+- `rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGoggles will output a warning if no rationale is provided.
 - `expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
 
 

--- a/docs/usage/Config.md
+++ b/docs/usage/Config.md
@@ -27,7 +27,7 @@ In some cases, it may be appropriate to omit specific policies from ScubaGoggles
 - When a policy is implemented by a third-party service that ScubaGoggles does not audit.
 - When a policy is not applicable to your organization (e.g., policy GWS.GMAIL.4.3v0.3, which is only applicable to federal, executive branch, departments and agencies).
 
-The `omitpolicy` top-level key, shown in this [example ScubaGoggles configuration file](/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGoggles report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
+The `omitpolicy` top-level key, shown in this [example ScubaGoggles configuration file](/sample-config-files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGoggles report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
 
 For each omitted policy, the config file allows you to indicate the following:
 - `rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGoggles will output a warning if no rationale is provided.

--- a/docs/usage/Config.md
+++ b/docs/usage/Config.md
@@ -11,7 +11,7 @@ All ScubaGoggles [parameters](/docs/usage/Parameters.md) can be placed into a co
 ### Basic Usage
 The [basic use](/sample-config-files/basic_config.yaml) example config file specifies the `outpath`, `baselines`, and `quiet` parameters.
 
-ScubaGoggles can be invokes with this config file:
+ScubaGoggles can be invoked with this config file:
 ```
 scubagoggles gws --config basic_config.yaml
 ```

--- a/docs/usage/Config.md
+++ b/docs/usage/Config.md
@@ -21,6 +21,19 @@ It can also be invoked while overriding the `baselines` parameter.
 scubagoggles gws --config basic_config.yaml -b gmail chat
 ```
 
+## Omit Policies
+
+In some cases, it may be appropriate to omit specific policies from ScubaGoggles evaluation. For example:
+- When a policy is implemented by a third-party service that ScubaGoggles does not audit
+- When a policy is not applicable to your organization (e.g., policy GWS.GMAIL.4.3v0.3 is only applicable to federal, executive branch, departments and agencies)
+
+The `OmitPolicy` top-level key, shown in this [example ScubaGoggles configuration file](https://github.com/cisagov/ScubaGear/blob/main/PowerShell/ScubaGear/Sample-Config-Files/omit_policies.yaml), allows the user to specify the policies that should be omitted from the ScubaGear report. Omitted policies will show up as "Omitted" in the HTML report and will be colored gray. Omitting policies must only be done if the omissions are approved within an organization's security risk management process. **Exercise care when omitting policies because this can inadvertently introduce blind spots when assessing your system.**
+
+For each omitted policy, the config file allows you to indicate the following:
+- `Rationale`: The reason the policy should be omitted from the report. This value will be displayed in the "Details" column of the report. ScubaGear will output a warning if no rationale is provided.
+- `Expiration`: Optional. A date after which the policy should no longer be omitted from the report. The expected format is yyyy-mm-dd.
+
+
 ## Navigation
 - Continue to [Usage: Examples](/docs/usage/Examples.md)
 - Return to [Documentation Home](/README.md)

--- a/sample-config-files/omit_policies.yaml
+++ b/sample-config-files/omit_policies.yaml
@@ -1,0 +1,16 @@
+# YAML configuration demonstrating omitting policies from ScubaGoggles evaluation.
+# Any omitted policies should be carefully considered and documented as part of an
+# organization's cybersecurity risk management program process and practices.
+
+baselines: [gmail, chat, drive]
+
+omitpolicy:
+  GWS.GMAIL.3.1v0.3:
+    rationale: "Known false positive; our SPF policy currently cannot to be retrieved via ScubaGoggles due to a split
+      horizon setup but is available publicly."
+    expiration: "2023-12-31"
+  GWS.CHAT.5.1v0.3:
+    rationale: &DLPRationale "The DLP capability required by the baselines is implemented by third party product, [x],
+      which ScubaGoggles does not have the ability to check."
+  GWS.DRIVEDOCS.7.1v0.3:
+    rationale: *DLPRationale


### PR DESCRIPTION
## 🗣 Description ##
Added config file support for omitting controls. See documentation here: https://github.com/cisagov/ScubaGoggles/blob/351-add-config-file-support-for-control-omission/docs/usage/Config.md#omit-policies.

### 💭 Motivation and context
Closes #351.

## 📷 Screenshots (if appropriate) ##
![image](https://github.com/user-attachments/assets/84449162-579c-4666-8dff-a5bb2b2dadf2)
![image](https://github.com/user-attachments/assets/f6b5c5de-09c0-40a1-bd43-cb446005f564)


## 🧪 Testing
Rationale left blank:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale:
```

Rationale empty:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: ""
```

Neither rationale nor expiration date provided:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
```

Rationale provided:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
```

omitpolicies left blank:
```
baselines: [drive]
omitpolicy:
```

expiration date in past:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
    expiration: "2023-12-31"
```

expiration date in future:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
    expiration: "2024-12-31"
```

expiration date empty:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
    expiration: ""
```

expiration date blank:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
    expiration:
```

expiration date malformed:
```
baselines: [drive]
omitpolicy:
  GWS.DRIVEDOCS.7.1v0.3:
    rationale: "example rationale"
    expiration: "hello world"
```

also omit_controls.yaml as is.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
