### PR TITLE
Implement Rego check for Common Controls early access app control 

### DIFF
--- a/Testing/RegoTests/commoncontrols/commoncontrols16_test.rego
+++ b/Testing/RegoTests/commoncontrols/commoncontrols16_test.rego
@@ -129,3 +129,316 @@ test_Unlisted_Incorrect_V2 if {
     ])
 }
 #--
+
+#
+# GWS.COMMONCONTROLS.16.2v0.3
+#--
+
+test_EarlyAccessApps_OUs_Correct_V1 if {
+    # Test 1 correct event
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2024-10-15T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
+}
+
+test_EarlyAccessApps_OUs_Correct_V2 if {
+    # Test inheritance
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "INHERIT_FROM_PARENT"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == "Requirement met in all OUs and groups."
+}
+
+test_EarlyAccessApps_OUs_Incorrect_V1 if {
+    # Test 1 incorrect event
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2024-05-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Top-Level OU: Service status is ON</li>",
+        "</ul>"
+    ])
+}
+
+test_EarlyAccessApps_OUs_Incorrect_V2 if {
+    # Test incorrect second-level OU
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Second-Level OU"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Second-Level OU: Service status is ON</li>",
+        "</ul>"
+    ])
+}
+
+test_EarlyAccessApps_OUs_Correct_Groups_Incorrect_V3 if {
+    # Test for correct OUs but with an incorrect group event
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "Test Group 1"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following groups are non-compliant:<ul>",
+        "<li>Test Group 1: Service status is ON</li>",
+        "</ul>"
+    ])
+}
+
+test_EarlyAccessApps_OUs_Correct_Groups_Incorrect_V3 if {
+    # Test for correct OUs but with incorrect group events
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "false"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "Test Group 1"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "Test Group 2"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following groups are non-compliant:<ul>",
+        "<li>Test Group 1: Service status is ON</li>",
+        "<li>Test Group 2: Service status is ON</li>",
+        "</ul>"
+    ])
+}
+
+test_EarlyAccessApps_OUs_Groups_Incorrect_V3 if {
+    # Test for both incorrect OUs and group events
+    PolicyId := "GWS.COMMONCONTROLS.16.2v0.3"
+    Output := tests with input as {
+        "commoncontrols_logs": {"items": [
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "ORG_UNIT_NAME", "value": "Test Top-Level OU"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "Test Group 1"},
+                    ]
+                }]
+            },
+            {
+                "id": {"time": "2022-12-20T00:02:28.672Z"},
+                "events": [{
+                    "name": "TOGGLE_SERVICE_ENABLED",
+                    "parameters": [
+                        {"name": "SERVICE_NAME", "value": "Early Access Apps"},
+                        {"name": "NEW_VALUE", "value": "true"},
+                        {"name": "GROUP_EMAIL", "value": "Test Group 2"},
+                    ]
+                }]
+            }
+        ]},
+        "tenant_info": {
+            "topLevelOU": "Test Top-Level OU"
+        }
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat("", [
+        "The following OUs are non-compliant:<ul>",
+        "<li>Test Top-Level OU: Service status is ON</li>",
+        #"<li>Test Second-Level OU: Service status is ON</li>",
+        "</ul><br>",
+        "The following groups are non-compliant:<ul>",
+        "<li>Test Group 1: Service status is ON</li>",
+        "<li>Test Group 2: Service status is ON</li>",
+        "</ul>"
+    ])
+}
+#--
+
+#"The following OUs are non-compliant:<ul><li>DHS-CISA: Service status is ON</li></ul><br>The following groups are non-compliant:<ul><li>Test Google Services: Service status is ON</li><li>Test Group: Service status is ON</li></ul>"


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->

Added Rego tests for the new Common Controls 16.2 policy. which checks if early access app control is turned off. 
Added unit tests to check for compliant/noncompliant settings for both OUs/groups. 

### 💭 Motivation and context

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Closes #402 

## 🧪 Testing

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Under Early Access Apps Access within Google Services:

OU testing:
- at the root OU set service status to OFF (report should indicate compliance)
- at the root OU set service status to ON (report should indicate noncompliance)
- at the root OU set service status to OFF, then set service status to ON at a sub OU (report should indicate noncompliance)
- at the root OU set service status to OFF along with inheritance for all sub OUs (report should indicate compliance)

Group testing: 
- at the root OU set service status to OFF, then set service status to OFF for all groups (report should indicate compliance)
- at the root OU set service status to OFF, then set service status to ON for one group (report should indicate noncompliance)
- at the root OU set service status to OFF, then set service status to ON for two groups (report should indicate noncompliance)
- at the root OU set service status to ON, then set service status to ON for one group (report should indicate noncompliance for both OUs and the group)
- at the root OU set service status to ON, then set service status to ON for two groups (report should indicate noncompliance for both OUs and groups)

Run unit tests with 
```
cd ./Testing
python ./run_unit_tests.py -b commoncontrols
```

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
