### PR TITLE
Remove Windows test from workflow default

### DIFF
--- a/.github/workflows/run_smoke_test.yml
+++ b/.github/workflows/run_smoke_test.yml
@@ -53,7 +53,7 @@ jobs:
 
           # Default values for other events
           else
-            operatingsystem_val="['windows-latest', 'macos-latest']"
+            operatingsystem_val="['macos-latest']"
             pythonversion_val="['3.10']"
             opaversion_val="0.60.0"
           fi


### PR DESCRIPTION
## 🗣 Description ##
Make it so the Windows smoke test isn't run by default. It can still triggered manually if desired.

### 💭 Motivation and context
Closes #533.
See #529 for the follow-up issue.

## 🧪 Testing
N/A

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
