### PR TITLE
Fixing Various Calendar Implementation Steps/Resources

### DIFF
--- a/scubagoggles/baselines/calendar.md
+++ b/scubagoggles/baselines/calendar.md
@@ -170,8 +170,9 @@ To configure the settings for Calendar Interop:
 1.  Sign in to the [Google Admin Console](https://admin.google.com).
 2.  Select **Apps -\> Google Workspace -\> Calendar**.
 3.  Select **Calendar Interop management**.
-4.  Uncheck the **Enable Interoperability for Calendar** checkbox.
-5.  Select **Save**.
+4.  Select **Exchange availability in Calendar**. 
+5.  Uncheck the **Enable Interoperability for Calendar** checkbox.
+6.  Select **Save**.
 
 #### GWS.CALENDAR.3.2v0.3 Instructions
 
@@ -180,8 +181,10 @@ To configure the settings for Calendar Interop:
 1.  Sign in to the [Google Admin Console](https://admin.google.com).
 2.  Select **Apps -\> Google Workspace -\> Calendar**.
 3.  Select **Calendar Interop management**.
-4.  Select **OAuth 2.0 client credentials**
-5.  Select **Save**.
+4.  Select **Exchange availability in Calendar**. 
+5.  Select **Allow Google Calendar to display Exchange users availability**.  
+6.  Select **OAuth 2.0 client credentials**
+7.  Select **Save**.
 
 ## 4. Paid Appointments
 
@@ -201,7 +204,7 @@ Appointment Schedule with Payments SHALL be disabled.
 
 ### Resources
 
--   [Google Workspace Help: Allow paid appointment schedules in Calendar](https://apps.google.com/supportwidget/articlehome?article_url=https%3A%2F%2Fsupport.google.com%2Fa%2Fanswer%2F13765946&assistant_id=generic-unu&product_context=13765946&product_name=UnuFlow&trigger_context=a)
+-   [Google Workspace Help: Allow paid appointment schedules in Calendar](https://support.google.com/a/answer/13765946?hl=en)
 
 ### Prerequisites
 
@@ -214,5 +217,5 @@ Appointment Schedule with Payments SHALL be disabled.
 1.  Sign in to the [Google Admin Console](https://admin.google.com).
 2.  Select **Apps -\> Google Workspace -\> Calendar**.
 3.  Select **Advanced Settings -\> Appointment schedules with payments**
-4.  Select **OFF- Blocks users' from adding required payments to their Calendar appointment schedules**
+4.  Ensure the **Allow appointment schedule users to require payments for booked appointments through their own payment provider accounts** checkbox is unchecked. 
 5.  Select **Save**


### PR DESCRIPTION
## 🗣 Description ##

Updating various implementation steps and resource links in calendar baseline

### 💭 Motivation and context

Google Admin console language was updated, so needed to update baseline to reflect what is shown in the admin console. 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

N/A

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
