### PR TITLE
Build Script: Update Default Repository from Private to Public

### DIFF
--- a/scubagoggles/utils/build.sh
+++ b/scubagoggles/utils/build.sh
@@ -32,7 +32,7 @@ shopt -s expand_aliases
 
 gitTag=
 outDir="$PWD"
-scubaGogglesGit='git@github.com:mitre/CISA-SCuBA-GWS-SCB.git'
+scubaGogglesGit='git@github.com:cisagov/ScubaGoggles.git'
 
 usage()
 {


### PR DESCRIPTION
## 🗣 Description ##

The package build script still had the private repository as the default for building the package.  Now that the Policy API work has been merged into the public repository, the build script needed to be updated to use the public repository.

Closes #568

## 🧪 Testing

I ran the build locally, taking the default for the repository.  It successfully cloned the public repository and the build completed successfully.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
