### PR TITLE
Adding in Policies for Meet for Automatic Recording and Transcription

### DIFF
--- a/scubagoggles/baselines/meet.md
+++ b/scubagoggles/baselines/meet.md
@@ -242,7 +242,9 @@ Automatic recordings for Google Meet SHALL be disabled.
 - _Last modified:_ January 2024
 
 - MITRE ATT&CK TTP Mapping
-  - 
+  - [T1123: Audio Capture](https://attack.mitre.org/techniques/T1123/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
 
 ### Resources
 - [Choose automatic meeting artifact settings for your organization](https://support.google.com/a/answer/15496523?p=automaticmeetingrecords)
@@ -257,7 +259,10 @@ Automatic transcripts for Google Meet SHALL be disabled.
 - _Last modified:_ January 2024
 
 - MITRE ATT&CK TTP Mapping
-  - 
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
+  - [T1048: Exfiltration Over Alternative Protocol](https://attack.mitre.org/techniques/T1048/)
+  - [T1565: Data Manipulation](https://attack.mitre.org/techniques/T1565/)
+
 
 ### Resources
 - [Choose automatic meeting artifact settings for your organization](https://support.google.com/a/answer/15496523?p=automaticmeetingrecords)

--- a/scubagoggles/baselines/meet.md
+++ b/scubagoggles/baselines/meet.md
@@ -228,3 +228,57 @@ Incoming calls SHALL be restricted to contacts and other users in the organizati
 4.  Click **Incoming call restrictions**.
 5.  Ensure **Users receive calls only from contacts and other users in the organization** or **Users can't receive calls** is selected.
 6.  Click **Save**.
+
+## 6. Automatic Meeting Recording and Transcripts
+
+This section covers automatic recording and transcripts for Google Meet.
+
+### Policies
+
+#### GWS.MEET.6.1v0.3
+Automatic recordings for Google Meet SHALL be disabled.
+
+- _Rationale:_ Automatic recordings could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.
+- _Last modified:_ January 2024
+
+- MITRE ATT&CK TTP Mapping
+  - 
+
+### Resources
+- [Choose automatic meeting artifact settings for your organization](https://support.google.com/a/answer/15496523?p=automaticmeetingrecords)
+
+### Prerequisites
+-   None
+
+#### GWS.MEET.6.2v0.3
+Automatic transcripts for Google Meet SHALL be disabled.
+
+- _Rationale:_ Automatic transcripts could record sensitive information. By selecting this setting, it potentially mitigates unauthorized data leakage.
+- _Last modified:_ January 2024
+
+- MITRE ATT&CK TTP Mapping
+  - 
+
+### Resources
+- [Choose automatic meeting artifact settings for your organization](https://support.google.com/a/answer/15496523?p=automaticmeetingrecords)
+
+### Prerequisites
+-   None
+
+### Implementation
+
+#### GWS.MEET.6.1v0.3 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Meet video settings**.
+4.  Click **Automatic recording**.
+5.  Ensure **Meetings are recorded by default** is unselected.
+6.  Click **Save**.
+
+#### GWS.MEET.6.2v0.3 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Meet video settings**.
+4.  Click **Automatic transcription**.
+5.  Ensure **Meetings are transcribed by default** is unselected.
+6.  Click **Save**. 


### PR DESCRIPTION
## 🗣 Description ##

Adding in new policies Meet 6.1 and 6.2

### 💭 Motivation and context

New update from Google about automated recording and transcripts, so updating policy to reflect best practices.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

N/A

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
