### PR TITLE
Updating Common Controls 1.2 to be at most 1 Week

### DIFF
--- a/drift-rules/GWS Drift Monitoring Rules - Common Controls as of 11-14-23.csv
+++ b/drift-rules/GWS Drift Monitoring Rules - Common Controls as of 11-14-23.csv
@@ -1,6 +1,6 @@
 PolicyId,Name,Data Source,Event (Is),Setting Name (Is),New Value (Is Not),Rule ID,Last Successful Test
 GWS.COMMONCONTROLS.1.1v0.3,Phishing-Resistant MFA SHALL be required for all users.,Admin Log Event,Enforce 2-Step Verification,No Setting Name,true,rules/00gjdgxs3twm54g,JK 08-02-23 @ 06:51
-GWS.COMMONCONTROLS.1.2v0.3,New user enrollment period SHALL be set to 1 week.,Admin Log Event,Change 2-Step Verification Enrollment Period Duration,No Setting Name,1 week,rules/00gjdgxs19shvvu,JK 08-02-23 @ 07:04
+GWS.COMMONCONTROLS.1.2v0.3,New user enrollment period SHALL be set to at most 1 week.,Admin Log Event,Change 2-Step Verification Enrollment Period Duration,No Setting Name,1 week,rules/00gjdgxs19shvvu,JK 08-02-23 @ 07:04
 GWS.COMMONCONTROLS.1.3v0.3,Allow users to trust the device SHALL be disabled.,Admin Log Event,Change 2-Step Verification Frequency,No Setting Name,ENABLE_USERS_TO_TRUST_DEVICE,rules/00gjdgxs15t2155,JK 08-02-23 @ 07:10
 GWS.COMMONCONTROLS.1.4v0.3,"If phishing-resistant MFA is not yet tenable, an MFA method from the following list SHALL be used in the interim.",Admin Log Event,Change Allowed 2-Step Verification Methods,No Setting Name,NO_TELEPHONY,rules/00gjdgxs3t3ug07,JK 08-02-23 @ 14:53
 GWS.COMMONCONTROLS.2.1v0.3,Policies restricting access to GWS based on signals about enterprise devices SHOULD be implemented.,Admin Log Event,Context Aware Access Enablement,No Setting Name,ENABLED,rules/00gjdgxs1qrcqvm,JK 08-02-23 @ 07:49

--- a/scubagoggles/baselines/commoncontrols.md
+++ b/scubagoggles/baselines/commoncontrols.md
@@ -93,7 +93,7 @@ Phishing-Resistant MFA SHALL be required for all users.
     - [T1566:001: Phishing: Spearphishing Attachment](https://attack.mitre.org/techniques/T1566/001/)
 
 #### GWS.COMMONCONTROLS.1.2v0.3
-Google 2SV new user enrollment period SHALL be set to 1 week.
+Google 2SV new user enrollment period SHALL be set to at most 1 week.
 
 - _Rationale:_ Enrollment must be enforced within a reasonable timeframe. 1 week balances the need for allowing new personnel time to set up their authentication methods and reducing the risks inherent to not enforcing MFA immediately.
 - _Last modified:_ August 17, 2023
@@ -193,7 +193,7 @@ To enforce Phishing-Resistant 2-Step Verification (MFA) for all users, use the G
 5.  Select **Save**
 
 #### GWS.COMMONCONTROLS.1.2v0.3 Instructions
-1.  Set **New user enrollment** period to **1 Week**.
+1.  Set **New user enrollment** period to at most **1 Week**.
 2.  Select **Save**
 
 #### GWS.COMMONCONTROLS.1.3v0.3 Instructions


### PR DESCRIPTION
## 🗣 Description ##

Updating language for agencies to pick a shorter enrollment period if they so choose. 

### 💭 Motivation and context

Internal Discussion based around https://github.com/cisagov/ScubaGoggles/pull/538

Closes #583 

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

N/A

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
