### PR TITLE
Common Controls 1.2: 2SV Enrollment Period Changes to Rego

### DIFF
--- a/scubagoggles/Testing/RegoTests/commoncontrols/commoncontrols_api01_test.rego
+++ b/scubagoggles/Testing/RegoTests/commoncontrols/commoncontrols_api01_test.rego
@@ -26,6 +26,10 @@ GoodCaseInputApi01 := {
         "nextOU": {
             "security_two_step_verification_grace_period": {
                 "enrollmentGracePeriod": "604800s"}
+        },
+        "thirdOU": {
+            "security_two_step_verification_grace_period": {
+                "enrollmentGracePeriod": "86400s"}
         }
     },
     "tenant_info": {
@@ -49,7 +53,7 @@ BadCaseInputApi01 := {
                 "allowEnrollment": false
             },
             "security_two_step_verification_grace_period": {
-                "enrollmentGracePeriod": "0s"}
+                "enrollmentGracePeriod": "1209600s"}
         },
         "nextOU": {
             "security_two_step_verification_enforcement": {
@@ -89,6 +93,9 @@ BadCaseInputApi01a := {
          "nextOU": {
             "security_login_challenges": {
                 "enableEmployeeIdChallenge": false
+            },
+            "security_two_step_verification_grace_period": {
+                "enrollmentGracePeriod": "0s"
             }
         }
     },
@@ -129,6 +136,16 @@ test_EnrollPeriod_Incorrect_1 if {
     Output := tests with input as BadCaseInputApi01
 
     failedOU := [{"Name": "topOU",
+                  "Value": NonComplianceMessage1_2(1209600,
+                                                   utils.DurationToSeconds("7d"))}]
+    FailTestOUNonCompliant(PolicyId, Output, failedOU)
+}
+
+test_EnrollPeriod_Incorrect_2 if {
+    PolicyId := CommonControlsId1_2
+    Output := tests with input as BadCaseInputApi01a
+
+    failedOU := [{"Name": "nextOU",
                   "Value": NonComplianceMessage1_2(0,
                                                    utils.DurationToSeconds("7d"))}]
     FailTestOUNonCompliant(PolicyId, Output, failedOU)

--- a/scubagoggles/rego/Commoncontrols.rego
+++ b/scubagoggles/rego/Commoncontrols.rego
@@ -337,10 +337,14 @@ Check1_2_OK if {
 
 Check1_2_OK if {PolicyApiInUse}
 
-NonComplianceMessage1_2(value, expected) := sprintf("New user enrollment period (%s) %s (%s)",
-                                                    [utils.GetFriendlyDuration(value),
-                                                    "doesn't match expected",
-                                                    utils.GetFriendlyDuration(expected)])
+Prefix1_2 := "New user enrollment period"
+NonComplianceMessage1_2(value,
+                        expected) := sprintf("%s is NONE", [Prefix1_2]) if {
+                            value == 0
+                        } else := sprintf("%s %s (longer than %s)",
+                                          [Prefix1_2,
+                                           utils.GetFriendlyDuration(value),
+                                           utils.GetFriendlyDuration(expected)])
 
 NonCompliantOUs1_2 contains {
     "Name": OU,
@@ -383,7 +387,10 @@ if {
     some OU, settings in input.policies
     enrollPeriod := settings.security_two_step_verification_grace_period.enrollmentGracePeriod
     enrollSeconds := utils.DurationToSeconds(enrollPeriod)
-    enrollSeconds != expectedPeriod
+    true in {
+        enrollSeconds == 0,
+        enrollSeconds > expectedPeriod
+    }
 }
 
 tests contains {

--- a/scubagoggles/rego/Utils.rego
+++ b/scubagoggles/rego/Utils.rego
@@ -598,7 +598,11 @@ DurationToSeconds(duration) := durationSeconds if {
 # will convert the given seconds to a duration other than seconds that will
 # (hopefully) make more sense to the user.
 
-GetFriendlyDuration(Seconds) := "30 days" if {
+GetFriendlyDuration(Seconds) := "180 days" if {
+    Seconds == 15552000
+} else := "90 days" if {
+    Seconds == 7776000
+} else := "30 days" if {
     Seconds == 2592000
 } else := "14 days" if {
     Seconds == 1209600


### PR DESCRIPTION
## 🗣 Description ##

Rego code for Common Controls baseline 1.2 has been modified in conjunction with the change in the baseline requirement that the enrollment period be 1 week or less, but not "none".

## 🧪 Testing

Test cases for 1.2 were added/modified to test for the following:

* enrollment period greater than a week
* enrollment period 1 week or less
* no enrollment period

In addition, manual testing was done using the `scubagws` tenant by varying the 2SV enrollment period values.

Closes #586

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
