### PR TITLE
Work-around for Policy API Missing OrgUnit in Settings (0.4.1) release

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </ul>
   <ul>
         <a href="https://github.com/cisagov/ScubaGoggles/releases">
-        <img src="https://img.shields.io/badge/ScubaGoggles-v0.4.0-%2385B065?labelColor=%23005288"  alt="ScubaGoggles version #"></a>
+        <img src="https://img.shields.io/badge/ScubaGoggles-v0.4.1-%2385B065?labelColor=%23005288"  alt="ScubaGoggles version #"></a>
         <a href="https://github.com/cisagov/ScubaGoggles/tree/main/baselines">
         <img src="https://img.shields.io/badge/GWS_SCB-v0.4-%2385B065?labelColor=%23005288" alt="GWS SCB version #"></a>
         <a href="">

--- a/scubagoggles/__init__.py
+++ b/scubagoggles/__init__.py
@@ -4,4 +4,4 @@ This file contains the OFFICIAL source of the ScubaGoggles version number.
 All other references to the version number are derived from this value.
 """
 
-__version__ = '0.4.0'
+__version__ = '0.4.1'

--- a/scubagoggles/policy_api.py
+++ b/scubagoggles/policy_api.py
@@ -608,9 +608,17 @@ class PolicyAPI:
             # For the current policy setting, use the returned org unit id
             # to get the org unit name, which is used as the key for the
             # result dictionary.
-            orgunit_id = policy['policyQuery']['orgUnit']
-            orgunit_id = orgunit_id.removeprefix('orgUnits/')
-            orgunit_name = self._orgunit_id_map[orgunit_id]['name']
+
+            if 'orgUnit' in policy['policyQuery']:
+                orgunit_id = policy['policyQuery']['orgUnit']
+                orgunit_id = orgunit_id.removeprefix('orgUnits/')
+                orgunit_name = self._orgunit_id_map[orgunit_id]['name']
+            else:
+                # NOTE: a policy setting should always be associated with
+                # an org unit.  In rare cases, an org unit is not provided,
+                # and in this case the policy is associated with the top-level
+                # org unit.
+                orgunit_name = self._top_orgunit
 
             if 'group' in policy['policyQuery']:
                 group_id = policy['policyQuery']['group']

--- a/scubagoggles/policy_api.py
+++ b/scubagoggles/policy_api.py
@@ -618,6 +618,9 @@ class PolicyAPI:
                 # an org unit.  In rare cases, an org unit is not provided,
                 # and in this case the policy is associated with the top-level
                 # org unit.
+                log.debug('Org unit data missing for "%s", '
+                          'assuming top-level OU.',
+                          policy['setting']['type'])
                 orgunit_name = self._top_orgunit
 
             if 'group' in policy['policyQuery']:


### PR DESCRIPTION
## 🗣 Description ##

This contains the fix for the Policy API not including the orgunit with the policy setting in some rare cases.  Google is looking into this issue, but this change will isolate us in the meantime.  The basic rule for the policy settings is that the top-level orgunit has all the settings and any subunit or group will only have settings that deviate from the top-level orgunit's settings.  It's appropriate to associate any setting without an orgunit with the top-level orgunit.

This also comes with the version update from 0.4.0 to 0.4.1.

Closes #599

## 🧪 Testing

Manual testing by faking out a setting without an orgunit.  The setting gets the top-level orgunit.

The smoke test does not run successfully as of when this PR was created, because the meet 6.* baseline was added in a prior commit in the main branch and there's no corresponding Rego implementation.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
