### PR TITLE
Implement Chat 3.1 Changes in Rego Code

### DIFF
--- a/scubagoggles/Testing/RegoTests/chat/chat_api03_test.rego
+++ b/scubagoggles/Testing/RegoTests/chat/chat_api03_test.rego
@@ -7,16 +7,11 @@ import data.utils.PassTestResult
 GoodChatApi03 := {
     "policies": {
         "topOU": {
-            "chat_space_history": {"historyState": "DEFAULT_HISTORY_ON"},
+            "chat_space_history": {"historyState": "HISTORY_ALWAYS_ON"},
             "chat_service_status": {"serviceState": "ENABLED"}
         },
          "nextOU": {
             "chat_space_history": {"historyState": "HISTORY_ALWAYS_ON"}
-        },
-        "thirdOU": {
-            "security_session_controls": {
-                "webSessionDuration": "700m"
-            }
         },
     },
     "tenant_info": {
@@ -48,6 +43,9 @@ BadChatApi03a := {
         "thirdOU": {
             "chat_space_history": {"historyState": "HISTORY_STATE_UNSPECIFIED"}
         },
+        "fourthOU": {
+            "chat_space_history": {"historyState": "DEFAULT_HISTORY_ON"}
+        },
      },
     "tenant_info": {
         "topLevelOU": "topOU"
@@ -74,7 +72,9 @@ test_ChatAPI_Space_History_Incorrect_2 if {
     PolicyId := ChatId3_1
     Output := tests with input as BadChatApi03a
 
-    failedOU := [{"Name": "secondOU",
+    failedOU := [{"Name": "fourthOU",
+                 "Value": NonComplianceMessage3_1("ON by default")},
+                 {"Name": "secondOU",
                  "Value": NonComplianceMessage3_1("ALWAYS OFF")},
                  {"Name": "thirdOU",
                  "Value": NonComplianceMessage3_1("Unspecified")}]

--- a/scubagoggles/rego/Chat.rego
+++ b/scubagoggles/rego/Chat.rego
@@ -157,7 +157,7 @@ NonCompliantOUs3_1 contains {
     some OU, settings in input.policies
     ChatEnabled(OU)
     spaceHistory := settings.chat_space_history.historyState
-    not spaceHistory in ["DEFAULT_HISTORY_ON", "HISTORY_ALWAYS_ON"]
+    spaceHistory != "HISTORY_ALWAYS_ON"
 }
 
 tests contains {
@@ -267,19 +267,19 @@ NonCompliantOUs5_1 contains {
     # these settings.
     OU != utils.TopLevelOU
 
+    # Ignore OUs without all event types. We're already asserting that the
+    # top-level OU has at least one event for all types; for all other OUs we assume
+    # they inherit from a parent OU if they have no events.
     OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
+    count(OneOnOneEvents) > 0
     GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
+    count(GroupEvents) > 0
     SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
+    count(SpacesEvents) > 0
 
     # This setting corresponds to the "All spaces" or "Discoverable spaces only" toggle under the Spaces box
     SpacesRestrictionEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_restrictions", OU)
 
-    # Ignore OUs without all event types. We're already asserting that the
-    # top-level OU has at least one event for all types; for all other OUs we assume
-    # they inherit from a parent OU if they have no events.
-    count(OneOnOneEvents) > 0
-    count(GroupEvents) > 0
-    count(SpacesEvents) > 0
     count(SpacesRestrictionEvents) > 0
 
     # Get the last event for each setting
@@ -305,19 +305,19 @@ NonCompliantOUs5_1 contains {
     # NOTE: the top-level OU is a special case, see comments above.
     OU := utils.TopLevelOU
 
+    # Ignore OUs without all event types. We're already asserting that the
+    # top-level OU has at least one event for all types; for all other OUs we assume
+    # they inherit from a parent OU if they have no events.
     OneOnOneEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto one_on_one_reporting", OU)
+    count(OneOnOneEvents) > 0
     GroupEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto group_chat_reporting", OU)
+    count(GroupEvents) > 0
     SpacesEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_reporting", OU)
+    count(SpacesEvents) > 0
 
     # This setting corresponds to the "All spaces" or "Discoverable spaces only" toggle under the Spaces box
     SpacesRestrictionEvents := utils.FilterEventsOU(LogEvents, "ContentReportingProto room_restrictions", OU)
 
-    # Ignore OUs without all event types. We're already asserting that the
-    # top-level OU has at least one event for all types; for all other OUs we assume
-    # they inherit from a parent OU if they have no events.
-    count(OneOnOneEvents) > 0
-    count(GroupEvents) > 0
-    count(SpacesEvents) > 0
     count(SpacesRestrictionEvents) > 0
 
     # Get the last event for each setting


### PR DESCRIPTION
Implemented the change to the Chat 3.1 baseline Rego code.  This changes the space history setting from either "default on" or "always on" to **only** "always on".

Also, modified code to clear Regal warnings about "defer-assignment".

Closes #654.

## 🧪 Testing

Modified the Chat 3.1 Rego tests to reflect the baseline change.
Tested manually using scubagws tenant.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
