### PR TITLE
Better error message for when authorized scopes do not match

### DIFF
--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -127,7 +127,7 @@ class GwsAuth:
 
             # Identifies the missing scope(s) from the token file.
             missing_scopes = list(set(valid_scopes).difference(token_scopes))
-            warnings.warn(f'Your credential is missing the ' 
+            warnings.warn(f'Your credential is missing the '
                           f'following scope(s): {str(missing_scopes)[1:-1]}')
 
     def _load_token(self):

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -127,7 +127,8 @@ class GwsAuth:
 
             # Identifies the missing scope(s) from the token file.
             missing_scopes = list(set(valid_scopes).difference(token_scopes))
-            warnings.warn(f'Your credential is missing the following scope(s): {str(missing_scopes)[1:-1]}')
+            warnings.warn(f'Your credential is missing the ' 
+                          f'following scope(s): {str(missing_scopes)[1:-1]}')
 
     def _load_token(self):
         """Loads and existing Google API token file, if it exists, and

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -5,6 +5,7 @@ This module uses a local credential.json file to authenticate to a GWS org
 """
 
 import json
+import warnings
 from pathlib import Path
 
 from google.auth.credentials import TokenState
@@ -123,6 +124,10 @@ class GwsAuth:
         # (with the user having to interact with the browser).
         if token_scopes != valid_scopes:
             self._token_path.unlink(missing_ok=True)
+
+            # Identifies the missing scope(s) from the token file.
+            missing_scopes = list(set(valid_scopes).difference(token_scopes))
+            warnings.warn(f'Your credential is missing the following scope(s): {str(missing_scopes)[1:-1]}')
 
     def _load_token(self):
         """Loads and existing Google API token file, if it exists, and

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -693,5 +693,5 @@ class Provider:
         # {'error': 'access_denied', 'error_description': 'Requested client not authorized.'})
         scopes_list = self._credentials.scopes
         if 'access_denied: Requested client not authorized.' in str(exc):
-            warnings.warn(f'Your credential may be missing one' 
+            warnings.warn(f'Your credential may be missing one'
                           f' of the following scopes: {scopes_list}')

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -688,9 +688,10 @@ class Provider:
         return results
 
     def _check_scopes(self, exc):
-        # If one of the scopes is not authorized in a Service account the 
-        # error is thrown: ('access_denied: Requested client not authorized.', 
+        # If one of the scopes is not authorized in a Service account the
+        # error is thrown: ('access_denied: Requested client not authorized.',
         # {'error': 'access_denied', 'error_description': 'Requested client not authorized.'})
-        scopes_list = GwsAuth._scopes
+        scopes_list = self._credentials.scopes
         if 'access_denied: Requested client not authorized.' in str(exc):
-            warnings.warn(f'Your credential may be missing one of the following scope: {scopes_list}')
+            warnings.warn(f'Your credential may be missing one' 
+                          f' of the following scopes: {scopes_list}')

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -403,6 +403,7 @@ class Provider:
                 f'Exception thrown while getting top level OU: {exc}',
                 RuntimeWarning
             )
+            self._check_scopes(exc)
             self._unsuccessful_calls.add(ApiReference.LIST_OUS.value)
             return 'Error Retrieving'
 
@@ -685,3 +686,11 @@ class Provider:
             request = resource.list_next(request, response)
 
         return results
+
+    def _check_scopes(self, exc):
+        # If one of the scopes is not authorized in a Service account the 
+        # error is thrown: ('access_denied: Requested client not authorized.', 
+        # {'error': 'access_denied', 'error_description': 'Requested client not authorized.'})
+        scopes_list = GwsAuth._scopes
+        if 'access_denied: Requested client not authorized.' in str(exc):
+            warnings.warn(f'Your credential may be missing one of the following scope: {scopes_list}')


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
Provides a better error message for when the authorized scopes do not match. There didn't seem to be a way to directly verify the authorized scopes for a service account, so if the service account does not have all the authorized scope, the error just indicates that one of the expected scopes are missing. The error message for OAuth, does indicate which scope is missing.

### 💭 Motivation and context
Closes #635 
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
For both OAuth and service accounts, change the authorized scopes for the user and verify the error message is shown.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [X] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels have been added.
- [X] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
