### PR TITLE
Restore Ability to Get Latest OPA Version

### DIFF
--- a/.github/actions/setup-dependencies-macos/action.yml
+++ b/.github/actions/setup-dependencies-macos/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Download OPA executable
       shell: bash
       env:
-        opa_version: ${{ inputs.opa-version == 'latest' && ' '
+        opa_version: ${{ inputs.opa-version == 'latest' && '-l'
           || format('-v {0}', inputs.opa-version) }}
       run: |
         ${{ env.SCUBAGOGGLES_ACTIVATE_VENV }}

--- a/.github/actions/setup-dependencies-windows/action.yml
+++ b/.github/actions/setup-dependencies-windows/action.yml
@@ -30,7 +30,7 @@ runs:
     - name: Download OPA executable
       shell: powershell
       env:
-        opa_version: ${{ inputs.opa-version == 'latest' && ' '
+        opa_version: ${{ inputs.opa-version == 'latest' && '-l'
           || format('-v {0}', inputs.opa-version) }}
       run: |
         ${{ env.SCUBAGOGGLES_ACTIVATE_VENV }}

--- a/scubagoggles/getopa.py
+++ b/scubagoggles/getopa.py
@@ -17,7 +17,6 @@ from urllib.parse import urljoin, urlsplit
 from urllib.request import Request, urlcleanup, urlopen, urlretrieve
 
 from scubagoggles.orchestrator import UserRuntimeError
-from scubagoggles.scuba_constants import OPA_VERSION
 from scubagoggles.utils import prompt_boolean
 
 log = logging.getLogger(__name__)
@@ -48,13 +47,18 @@ def getopa(arguments: argparse.Namespace):
 
     verify = not arguments.nocheck
     force = arguments.force
-    version = arguments.version.lower() if arguments.version else None
+
+    # The user can specify either to download the latest version, a specific
+    # version, or the default if no version options are given on the command
+    # line.
+
+    version = None if arguments.latest else arguments.version.lower()
 
     download_opa(opa_dir, version, verify, force)
 
 
 def download_opa(opa_dir: Path,
-                 version: str = OPA_VERSION,
+                 version: str = None,
                  verify: bool = False,
                  force: bool = False):
 

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -237,19 +237,25 @@ def get_opa_args(parser: argparse.ArgumentParser, user_config: UserConfig):
                         action='store_true',
                         help='Overwrite existing OPA executable')
 
-    parser.add_argument('--version',
-                        '-v',
-                        default = OPA_VERSION,
-                        metavar = '<OPA-version>',
-                        help = 'Version of OPA to download (default: latest '
-                            'version)')
-
     parser.add_argument('--opa_directory',
                         '-r',
                         metavar='<directory>',
                         type=path_parser,
                         help='Directory containing OPA executable')
 
+    version_group = parser.add_mutually_exclusive_group()
+
+    version_group.add_argument('--latest',
+                               '-l',
+                               action='store_true',
+                               help='Download latest OPA version')
+
+    version_group.add_argument('--version',
+                               '-v',
+                               default = OPA_VERSION,
+                               metavar = '<OPA-version>',
+                               help = 'Version of OPA to download (default: '
+                                   f'{OPA_VERSION})')
 
 def get_setup_args(parser: argparse.ArgumentParser, user_config: UserConfig):
     """Adds the arguments for the setup parser


### PR DESCRIPTION
## 🗣 Description ##

Added `--latest` option to `getopa` command to restore the ability to get the latest OPA version without having to know the version number for the latest release.

Fixed the help output for the `getopa` command to correct the default version being downloaded:

```
usage: scuba.py getopa [-h] [--nocheck] [--force] [--opa_directory <directory>] [--latest | --version <OPA-version>]

Download OPA executable

options:
  -h, --help            show this help message and exit
  --nocheck, -nc        Do not check hash code after download
  --force, -f           Overwrite existing OPA executable
  --opa_directory <directory>, -r <directory>
                        Directory containing OPA executable
  --latest, -l          Download latest OPA version
  --version <OPA-version>, -v <OPA-version>
                        Version of OPA to download (default: v1.0.1)
```

Fixed the Smoke Test workflow so that it downloads the latest version of OPA by default, instead of the locked-in default version.  This allows us to keep up with any Rego changes that might affect our code.

Closes #675.

## 🧪 Testing

Manually tested the `getopa --latest` command, making sure that it downloads the latest OPA version.  Ran the smoke test and checked that downloads the correct OPA version.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
