### PR TITLE
Update Deprecated License Configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = ["dnspython>=2.6.1",
 requires-python = ">= 3.9"
 description='SCuBA security baseline assessment tool'
 authors = [{name = "CISA"}]
-license = {file = "LICENSE"}
+license = "CC0-1.0"
+license-files = ["LICENSE"]
 readme = "README.md"
 
 [project.scripts]


### PR DESCRIPTION
## 🗣 Description ##

Updated the license information in `pyproject.toml` according to PEP 639.  This change stops the deprecation warnings during the release build.

## 🧪 Testing

Ran the build script (`scubagoggles/utils/build.sh`) using this branch.  The deprecation warning about the license configuration is no longer displayed, and the license file is still included in the ScubaGoggles release package.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
