### PR TITLE
Update drive prereqs

### DIFF
--- a/scubagoggles/rego/Drive.rego
+++ b/scubagoggles/rego/Drive.rego
@@ -350,7 +350,6 @@ if {
 tests contains {
     "PolicyId": DriveId1_6,
     "Prerequisites": [
-        "policy/drive_and_docs_external_sharing.externalSharingMode",
         "policy/drive_and_docs_external_sharing.accessCheckerSuggestions",
         "policy/drive_and_docs_service_status.serviceState"
     ],

--- a/scubagoggles/rego/Drive.rego
+++ b/scubagoggles/rego/Drive.rego
@@ -53,6 +53,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_1,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_1},
@@ -121,6 +125,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_2,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.allowReceivingFilesOutsideAllowlistedDomains",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_2, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_2},
@@ -181,6 +190,12 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_3,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.warnForExternalSharing",
+        "policy/drive_and_docs_external_sharing.warnForSharingOutsideAllowlistedDomains",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_3, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_3},
@@ -242,6 +257,12 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_4,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.allowNonGoogleInvites",
+        "policy/drive_and_docs_external_sharing.allowNonGoogleInvitesInAllowlistedDomains",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_4, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_4},
@@ -283,6 +304,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_5,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.allowPublishingFiles",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_5, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_5},
@@ -323,6 +349,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_6,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.accessCheckerSuggestions",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_6, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_6},
@@ -372,6 +403,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_7,
+    "Prerequisites": [
+        "policy/drive_and_docs_external_sharing.externalSharingMode",
+        "policy/drive_and_docs_external_sharing.allowedPartiesForDistributingContent",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_7, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_7},
@@ -413,6 +449,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId1_8,
+    "Prerequisites": [
+        "policy/drive_and_docs_general_access_default.defaultFileAccess",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs1_8, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs1_8},
@@ -449,6 +489,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId2_1,
+    "Prerequisites": [
+        "policy/drive_and_docs_shared_drive_creation.allowManagersToOverrideSettings",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs2_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_1},
@@ -481,6 +525,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId2_2,
+    "Prerequisites": [
+        "policy/drive_and_docs_shared_drive_creation.allowExternalUserAccess",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs2_2, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_2},
@@ -513,6 +561,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId2_3,
+    "Prerequisites": [
+        "policy/drive_and_docs_shared_drive_creation.allowNonMemberAccess",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs2_3, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_3},
@@ -545,6 +597,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId2_4,
+    "Prerequisites": [
+        "policy/drive_and_docs_shared_drive_creation.allowedPartiesForDownloadPrintCopy",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs2_4, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs2_4},
@@ -591,6 +647,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId3_1,
+    "Prerequisites": [
+        "policy/drive_and_docs_file_security_update.allowUsersToManageUpdate",
+        "policy/drive_and_docs_file_security_update.securityUpdate",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs3_1, []),
     "ActualValue" : {"NonCompliantOUs": NonCompliantOUs3_1},
@@ -627,6 +688,10 @@ if {
 
 tests contains {
     "PolicyId": DriveId4_1,
+    "Prerequisites": [
+        "policy/drive_and_docs_drive_sdk.enableDriveSdkApiAccess",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs4_1, []),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs4_1},
@@ -698,6 +763,7 @@ if {
 
 tests contains {
     "PolicyId": DriveId5_1,
+    "Prerequisites": ["reports/v1/activities/list"],
     "Criticality": "Shall",
     "ReportDetails": utils.NoSuchEventDetails(DefaultSafe, utils.TopLevelOU),
     "ActualValue": "No relevant event for the top-level OU in the current logs",
@@ -711,6 +777,7 @@ if {
 
 tests contains {
     "PolicyId": DriveId5_1,
+    "Prerequisites": ["reports/v1/activities/list"],
     "Criticality": "Shall",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs5_1, NonCompliantGroups5_1),
     "ActualValue": {"NonCompliantOUs": NonCompliantOUs5_1,
@@ -771,6 +838,11 @@ if {
 
 tests contains {
     "PolicyId": DriveId6_1,
+    "Prerequisites": [
+        "policy/drive_and_docs_drive_for_desktop.allowDriveForDesktop",
+        "policy/drive_and_docs_drive_for_desktop.restrictToAuthorizedDevices",
+        "policy/drive_and_docs_service_status.serviceState"
+    ],
     "Criticality": "Should",
     "ReportDetails": utils.ReportDetails(NonCompliantOUs6_1, []),
     "ActualValue" : {"NonCompliantOUs": NonCompliantOUs6_1},


### PR DESCRIPTION
## 🗣 Description ##
Updates the prereqs for Drive to explicitly state the API dependencies (e.g., the policy or reports API) for better error handling.

### 💭 Motivation and context
Closes #664.
Contributes to but does not close #512.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
Ran ScubaGoggles manually, worked as expected.

For details on how to simulate policy API errors, see the testing section of https://github.com/cisagov/ScubaGoggles/pull/669.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
