### PR TITLE
Determine top-level OU when no custom OUs present

### DIFF
--- a/scubagoggles/policy_api.py
+++ b/scubagoggles/policy_api.py
@@ -853,7 +853,7 @@ class PolicyAPI:
 
         if not orgunit_policies:
             log.warning('No policy settings found for orgunit: %s', orgunit)
-            return False
+            return set()
 
         missing_settings = set()
         invalid_settings = set()

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -401,6 +401,7 @@ class Provider:
                 return ou['name']
 
         log.warning('Unable to determine the name of the top-level OU.')
+        return ''
 
     def get_tenant_info(self) -> dict:
         """


### PR DESCRIPTION
## 🗣 Description ##
A long-standing limitation of ScubaGoggles was that it couldn't reliably get the name of the top-level OU when no custom OUs had been created. This finally fixes that issue. It was as simple as changing `type` to `allIncludingParent` in the `orgunits.list` call.

### 💭 Motivation and context
Closes #691.
Closes #692.

## 🧪 Testing
Manually tested, in both a tenant with custom OUs and in a tenant without.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
