### PR TITLE
Set GWS.COMMONCONTROLS.13.1 Criticality to 'Shall/Not-Implemented'

### DIFF
--- a/scubagoggles/rego/Commoncontrols.rego
+++ b/scubagoggles/rego/Commoncontrols.rego
@@ -1691,7 +1691,7 @@ CommonControls13_1_Details(TotalRuleCount, EnabledRulesCount, DisabledRulesCount
 tests contains {
     "PolicyId": CommonControlsId13_1,
     "Prerequisites": ["reports/v1/activities/list"],
-    "Criticality": "Shall",
+    "Criticality": "Shall/Not-Implemented",
     "ReportDetails": CommonControls13_1_Details(TotalRuleCount, EnabledRulesCount, DisabledRulesCount),
     "ActualValue": {
         "enabled_rules": EnabledAdminCenterRules | EnabledEmailOnlyRules,


### PR DESCRIPTION
## 🗣 Description ##

Updates the commoncontrols.rego policy to set the Criticality of GWS.COMMONCONTROLS.13.1 to "Shall/Not-Implemented"

### 💭 Motivation and context

Closes #689 

## 📷 Screenshots  ##
![image](https://github.com/user-attachments/assets/952c6ed3-6ee9-4e44-a6c3-910016e40b15)

## 🧪 Testing
Manually tested, works as expected. I looked at both the HTML and JSON output to verify that the Criticality of GWS.COMMONCONTROLS.13.1 has been changed to "Shall/Not-Implemented"

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [X] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels have been added.
- [X] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
