### PR TITLE
Add missing default values for policy API

### DIFF
--- a/scubagoggles/policy_api.py
+++ b/scubagoggles/policy_api.py
@@ -295,6 +295,7 @@ class PolicyAPI:
     # documented defaults must be kept current with the implementation).
 
     _defaults = {
+        'calendar_external_invitations': {'warnOnInvite': True},
         'chat_chat_history': {'allowUserModification': True,
                               'historyOnByDefault': False},
         'chat_external_chat_restriction': {
@@ -318,6 +319,11 @@ class PolicyAPI:
             'enableGoogleWorkspaceSyncForMicrosoftOutlook': True},
         'gmail_email_spam_filter_ip_allowlist': {
             'allowedIpAddresses': []},
+        'gmail_links_and_external_images': {
+            'applyFutureSettingsAutomatically': True,
+            'enableAggressiveWarningsOnUntrustedLinks': False},
+        'gmail_spoofing_and_authentication': {
+            'applyFutureSettingsAutomatically': True},
         'groups_for_business_groups_sharing': {
             'collaborationCapability': 'DOMAIN_USERS_ONLY',
             'createGroupsAccessLevel': 'USERS_IN_DOMAIN',


### PR DESCRIPTION
## 🗣 Description ##
Google recently updated their list of default values: https://cloud.google.com/identity/docs/concepts/policy-api-concepts#default_field_values. This PR updates the dictionary of default values in policy_api.py to reflect those changes.

### 💭 Motivation and context
Closes #617.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
I manually tested in TestTenant2. Errors are now gone.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
