### PR TITLE
Add omit summary count

### DIFF
--- a/scubagoggles/reporter/reporter.py
+++ b/scubagoggles/reporter/reporter.py
@@ -579,6 +579,8 @@ class Reporter:
                     omitted_result = 'N/A'
                     omitted_details = 'N/A'
 
+                    report_stats['Omit'] += 1
+
                     for test in tests:
                         result = self._get_test_result(test['RequirementMet'],
                                                         test['Criticality'],

--- a/scubagoggles/reporter/styles/FrontPageStyle.css
+++ b/scubagoggles/reporter/styles/FrontPageStyle.css
@@ -13,8 +13,9 @@ footer {
 
 .summary {
     display: inline-block;
-    padding: 5px;
-    border-radius: 5px;
+    padding: 0.313em;
+    border-radius: 0.313em;
+    margin-right: 0.25em;
     min-width: 100px;
     text-align: center;
 }


### PR DESCRIPTION
## 🗣 Description ##
Add the omitted controls to the summary counts. Also, I added a bit of white space between the summary elements in the HTML, having the two gray summary elements touching bugged me, plus this more closely matches what ScubaGear looks like now.

### 💭 Motivation and context
Closes #707.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing
Manually tested, works as expected.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
