### PR TITLE
Dark mode improvements

### DIFF
--- a/scubagoggles/reporter/scripts/main.js
+++ b/scubagoggles/reporter/scripts/main.js
@@ -159,10 +159,10 @@ const mountDarkMode = () => {
     }
 
     // Next, check to see if the user specified the dark mode via the --darkmode
-    // CLI argument. The Python code dynamically inserts with the value of that
-    // arg as the "data-darkmode" attribute of the #sgr_settings element.
-    // The value will be a string, either "true" (dark mode is enabled), "false"
-    // (disabled), or "None" (not specified).
+    // CLI argument. The Python code dynamically inserts the value of that arg
+    // as the "data-darkmode" attribute of the #sgr_settings element. The value
+    // will be a string, either "true" (dark mode is enabled), "false" (disabled),
+    // or "None" (not specified).
     const cliElement = document.getElementById("sgr_settings");
     const cliElementValue = cliElement.getAttribute("data-darkmode");
     if (cliElementValue !== "None") {

--- a/scubagoggles/reporter/styles/FrontPageStyle.css
+++ b/scubagoggles/reporter/styles/FrontPageStyle.css
@@ -22,7 +22,7 @@ footer {
 
 a.individual_reports:link {
     font-family: Arial, Helvetica, sans-serif;
-    color: #005288;
+    color: var(--unvisited-link-color);
     text-decoration: underline;
 }
 

--- a/scubagoggles/reporter/styles/main.css
+++ b/scubagoggles/reporter/styles/main.css
@@ -42,29 +42,6 @@ html[data-theme='dark'] {
     --border-color: #7b7b7b;
 }
 
-@media (prefers-color-scheme: dark) {
-    :root, html > * {
-        --background-primary: #10171D;
-        --background-secondary: #121212;
-        --test-pass: #1C361C;
-        --test-fail: #381919;
-        --test-warning: #524100;
-        --test-other: #414141;
-        --cap-even: #0052882d;
-        --cap-hover: #007ccf50;
-        --test-error-color: #FD885D;
-        --header-color: #b7c8d2;
-        --note-color: #ee4e04;
-        --header-bottom: rgb(221, 221, 221);
-        --link-color: #9bc2a3;
-        --unvisited-link-color: #4da6d1;
-        --text-color: #bdbdbd;
-        --uuid-color: #999999;
-        --border-color: #7b7b7b;
-    }
-}
-
-
 body {
     background-color: var(--background-secondary);
     -webkit-print-color-adjust:exact !important;


### PR DESCRIPTION
## 🗣 Description ##
- Fix issue where links were hard to read in dark mode
- Fix issue where report was locked in dark mode

### 💭 Motivation and context
Closes #779.

Also fixes a bug where report would stay in dark mode even if you toggled it off. The issue appears to have something to do the system dark mode preference because removing the `@media (prefers-color-scheme: dark)` block from the CSS fixed the issue.

## 📷 Screenshots ##
Here is an example of what it looked like before:
<img width="667" height="412" alt="image" src="https://github.com/user-attachments/assets/6a42b697-ed07-45ba-a93a-ac0717dc0f2d" />

Even if you toggled dark mode off, it stayed in dark mode.

New link color:
<img width="250" height="74" alt="Screenshot 2025-10-07 074819" src="https://github.com/user-attachments/assets/60793713-1958-41a9-95a8-b9b7e13e142d" />


## 🧪 Testing
I tested the following scenarios:
- System preference is dark mode and `--darkmode` argument not used
- System preference is dark mode and `--darkmode "true"`
- System preference is dark mode and `--darkmode "false`
- System preference is light mode and `--darkmode` argument not used
- System preference is light mode and `--darkmode "true"`
- System preference is light mode and `--darkmode "false`

For each test, I ensured that 1) the report defaulted to the correct mode, 2) dark mode could be toggled on/off, and 3) color modes were consistent between the main report and sub-reports (i.e., if you toggle dark mode off in the main report then open the Common Controls report dark mode would still be off).

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
