### PR TITLE
Fix DMARC validation to reject domains with multiple records

### DIFF
--- a/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
@@ -101,6 +101,58 @@ test_DMARC_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
 }
 
+test_DMARC_Multiple_Records_V1 if {
+    # Test DMARC when a domain has multiple DMARC records (should FAIL per RFC 7489)
+    PolicyId := GmailId4_1
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov",
+                    "v=DMARC1; p=quarantine; pct=100; rua=mailto:admin@test.name"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARC_Multiple_Records_V2 if {
+    # Test DMARC when one domain has single record and another has multiple (mixed scenario)
+    PolicyId := GmailId4_1
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "good.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov"
+                ]
+            },
+            {
+                "domain": "bad.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov",
+                    "v=DMARC1; p=quarantine; pct=50; rua=mailto:admin@bad.name"
+                ]
+            }
+        ],
+        "domains": ["good.name", "bad.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 2 agency domain(s) found in violation: bad.name.", DNSLink])
+}
+
 #
 # GWS.GMAIL.4.2
 #--
@@ -189,6 +241,29 @@ test_DMARCMessageReject_Incorrect_V2 if {
             {
                 "domain": "test.name",
                 "rdata": ["v=DMARC1; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCMessageReject_Multiple_Records if {
+    # Test that domains with multiple DMARC records fail p=reject check
+    PolicyId := GmailId4_2
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov",
+                    "v=DMARC1; p=quarantine; pct=100; rua=mailto:admin@test.name"
+                ]
             }
         ],
         "domains": ["test.name"]
@@ -301,6 +376,29 @@ test_DMARCAggregateReports_Incorrect_V2 if {
     RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
 }
 
+test_DMARCAggregateReports_Multiple_Records if {
+    # Test that domains with multiple DMARC records fail DHS contact check
+    PolicyId := GmailId4_3
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov",
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:reports@dmarc.cyber.dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
 #
 # GWS.GMAIL.4.4
 #--
@@ -389,6 +487,29 @@ test_DMARCAgencyPOC_Incorrect_V2 if {
             {
                 "domain": "test.name",
                 "rdata": ["v=DMARC1; p=reject; pct=100; mailto:reports@dmarc.cyber.dhs.gov"]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Multiple_Records if {
+    # Test that domains with multiple DMARC records fail agency POC check
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov",
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:admin@test.name, mailto:reports@dmarc.cyber.dhs.gov"
+                ]
             }
         ],
         "domains": ["test.name"]

--- a/scubagoggles/rego/Gmail.rego
+++ b/scubagoggles/rego/Gmail.rego
@@ -153,10 +153,15 @@ if {
 GmailId4_1 := utils.PolicyIdWithSuffix("GWS.GMAIL.4.1")
 
 # Not applicable at OU or Group level
+# Per RFC 7489, if multiple DMARC records are found for a domain, stop processing
+# Only accept domains with exactly ONE valid DMARC record
 DomainsWithDmarc contains DmarcRecord.domain if {
     some DmarcRecord in input.dmarc_records
-    some Rdata in DmarcRecord.rdata
-    startswith(Rdata, "v=DMARC1;")
+    ValidDmarcRecords := [Rdata |
+        some Rdata in DmarcRecord.rdata
+        startswith(Rdata, "v=DMARC1;")
+    ]
+    count(ValidDmarcRecords) == 1
 }
 
 tests contains {
@@ -185,9 +190,15 @@ if {
 GmailId4_2 := utils.PolicyIdWithSuffix("GWS.GMAIL.4.2")
 
 # Not applicable at OU or Group level
+# Per RFC 7489, only process domains with exactly one DMARC record
 DomainsWithPreject contains DmarcRecord.domain if {
     some DmarcRecord in input.dmarc_records
-    some Rdata in DmarcRecord.rdata
+    ValidDmarcRecords := [Rdata |
+        some Rdata in DmarcRecord.rdata
+        startswith(Rdata, "v=DMARC1;")
+    ]
+    count(ValidDmarcRecords) == 1
+    some Rdata in ValidDmarcRecords
     contains(Rdata, "p=reject;")
 }
 
@@ -213,9 +224,15 @@ if {
 GmailId4_3 := utils.PolicyIdWithSuffix("GWS.GMAIL.4.3")
 
 # Not applicable at OU or Group level
+# Per RFC 7489, only process domains with exactly one DMARC record
 DomainsWithDHSContact contains DmarcRecord.domain if {
     some DmarcRecord in input.dmarc_records
-    some Rdata in DmarcRecord.rdata
+    ValidDmarcRecords := [Rdata |
+        some Rdata in DmarcRecord.rdata
+        startswith(Rdata, "v=DMARC1;")
+    ]
+    count(ValidDmarcRecords) == 1
+    some Rdata in ValidDmarcRecords
     contains(Rdata, "mailto:reports@dmarc.cyber.dhs.gov")
 }
 
@@ -241,9 +258,15 @@ if {
 GmailId4_4 := utils.PolicyIdWithSuffix("GWS.GMAIL.4.4")
 
 # Not applicable at OU or Group level
+# Per RFC 7489, only process domains with exactly one DMARC record
 DomainsWithAgencyContact contains DmarcRecord.domain if {
     some DmarcRecord in input.dmarc_records
-    some Rdata in DmarcRecord.rdata
+    ValidDmarcRecords := [Rdata |
+        some Rdata in DmarcRecord.rdata
+        startswith(Rdata, "v=DMARC1;")
+    ]
+    count(ValidDmarcRecords) == 1
+    some Rdata in ValidDmarcRecords
     count(split(Rdata, "@")) >= 3
 }
 


### PR DESCRIPTION
## Motivation and Context
Closes #849

Per RFC 7489, if multiple DMARC records are found for a domain, DMARC processing should stop. This fix ensures ScubaGoggles properly fails validation for domains with multiple DMARC records, aligning behavior with actual mail server implementations.

Without this fix, organizations may receive false positives for DMARC compliance when their DNS configuration is actually invalid and would be rejected by real mail servers.

## Changes Made
- Modified `DomainsWithDmarc` to only accept domains with exactly one valid DMARC record (v=DMARC1;)
- Updated `DomainsWithPreject`, `DomainsWithDHSContact`, and `DomainsWithAgencyContact` to validate single record requirement before checking other DMARC properties
- Added comprehensive unit tests to verify multiple DMARC records fail validation across all DMARC policies (GWS.GMAIL.4.x)

## Test Results
✅ All 122 Gmail unit tests passed
- Added 5 new test cases specifically for multiple DMARC record scenarios
- All existing tests continue to pass

## Files Changed
- `scubagoggles/rego/Gmail.rego` - DMARC validation logic
- `scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego` - Unit tests

## Pre-Approval Checklist
- [x] This PR has an informative and human-readable title
- [x] Changes are limited to a single goal (no scope creep)
- [x] Code passed all unit tests
- [x] Code follows style guide and coding conventions
- [x] New tests added to validate the fix