### PR TITLE
Fix Gemini service dependency bug (#795)

### DIFF
--- a/scubagoggles/Testing/Unit/Rego/gemini/gemini02_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gemini/gemini02_test.rego
@@ -24,7 +24,7 @@ test_2_1_Correct_V1 if {
         ]},
         "policies": {
             "topOU": {
-                "gemini_app_service_status": {"serviceState": "ENABLED"}
+                "gemini_for_workspace_service_status": {"serviceState": "ENABLED"}
             }
         },
         "tenant_info": {
@@ -60,7 +60,7 @@ test_2_1_Correct_V2 if {
         ]},
         "policies": {
             "topOU": {
-                "gemini_app_service_status": {"serviceState": "DISABLED"}
+                "gemini_for_workspace_service_status": {"serviceState": "DISABLED"}
             }
         },
         "tenant_info": {
@@ -122,7 +122,7 @@ test_2_1_Correct_V3 if {
         ]},
         "policies": {
             "topOU": {
-                "gemini_app_service_status": {"serviceState": "ENABLED"}
+                "gemini_for_workspace_service_status": {"serviceState": "ENABLED"}
             }
         },
         "tenant_info": {
@@ -159,7 +159,7 @@ test_2_1_Incorrect_V1 if {
         ]},
         "policies": {
             "topOU": {
-                "gemini_app_service_status": {"serviceState": "ENABLED"}
+                "gemini_for_workspace_service_status": {"serviceState": "ENABLED"}
             }
         },
         "tenant_info": {
@@ -212,7 +212,7 @@ test_2_1_Incorrect_V2 if {
         ]},
         "policies": {
             "topOU": {
-                "gemini_app_service_status": {"serviceState": "ENABLED"}
+                "gemini_for_workspace_service_status": {"serviceState": "ENABLED"}
             }
         },
         "tenant_info": {


### PR DESCRIPTION
## Summary

Fixes #795 - GWS.GEMINI.2.1 was incorrectly checking the "gemini_app" service status instead of the "gemini_for_workspace" service status, causing false positives when Gemini for Workspace was enabled with alpha features but the standalone Gemini App was disabled.

## Root Cause

The single `GeminiEnabled()` function was used for both:
- GWS.GEMINI.1.1 (Gemini App Access)
- GWS.GEMINI.2.1 (Alpha Workspace features)

These are separate services in Google Workspace with independent enable/disable states:
- **"gemini_app"** = Standalone Gemini application
- **"gemini_for_workspace"** = Gemini features in Workspace apps (Docs, Sheets, etc.)

## Changes

### Gemini.rego
1. Split service check into two functions:
   - `GeminiAppEnabled()` - checks "gemini_app" service
   - `GeminiForWorkspaceEnabled()` - checks "gemini_for_workspace" service

2. Split `NonCompliantOUs` rule into two separate rules:
   - GWS.GEMINI.1.1 uses `GeminiAppEnabled()`
   - GWS.GEMINI.2.1 uses `GeminiForWorkspaceEnabled()`

3. Split `NonCompliantGroups` rule similarly

4. Updated test prerequisites to reference correct service status for each control

### gemini02_test.rego
- Updated all test data to use "gemini_for_workspace_service_status" instead of "gemini_app_service_status"

## Testing

All 10 Gemini unit tests pass:
- gemini01_test.rego (GWS.GEMINI.1.1): 5/5 tests passed
- gemini02_test.rego (GWS.GEMINI.2.1): 5/5 tests passed

## Test Scenarios Verified

1. Both services enabled with alpha features: Both controls fail appropriately
2. Gemini App disabled, Workspace enabled with alpha: 1.1 passes, 2.1 fails correctly
3. Both services disabled: Both controls pass
4. Service inheritance across OUs handled correctly
5. Group settings respect parent OU service status