### PR TITLE
Policy change for drive docs 1.9

### DIFF
--- a/scubagoggles/baselines/drive.md
+++ b/scubagoggles/baselines/drive.md
@@ -155,16 +155,6 @@ If receiving external files isn’t allowed, then users in your organization SHO
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
   - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
 
-#### GWS.DRIVEDOCS.1.12v0.6
-If external sharing files externally or recieving external files is allowed, then the "Highlight External Files" setting SHALL be enabled.
-
-- _Rationale:_ If users are able to  share files externally and/or recieve files owned by an external individual, enabling this setting ensures that users are made aware that external users can see/edit the document via the label.
-- _Last modified:_ December 2025
-- Insert NIST Mapping Here
-- MITRE ATT&CK TTP Mapping
-  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
-  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
-
 
 ### Resources
 
@@ -219,7 +209,7 @@ To configure the settings for Sharing options:
 2.  Select **When users in your organization create items, the default access will be -\> Private to the owner.**
 
 #### GWS.DRIVEDOCS.1.9v0.6 Instructions
-1.  Select **Sharing settings -\> Sharing options**
+1.  Select **Sharing settings -\> Highlight External Files**
 2.  Select **Highlight external files**
 3.  Check the **Highlight external Files** box to turn on the indicator.
 4.  Select **Save**.

--- a/scubagoggles/baselines/drive.md
+++ b/scubagoggles/baselines/drive.md
@@ -209,8 +209,7 @@ To configure the settings for Sharing options:
 2.  Select **When users in your organization create items, the default access will be -\> Private to the owner.**
 
 #### GWS.DRIVEDOCS.1.9v0.6 Instructions
-1.  Select **Sharing settings -\> Highlight External Files**
-2.  Select **Highlight external files**
+1.  Select **Sharing settings -\> Highlight External Files**.
 3.  Check the **Mark files shared or owned externally as "external" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.
 4.  Select **Save**.
 

--- a/scubagoggles/baselines/drive.md
+++ b/scubagoggles/baselines/drive.md
@@ -155,6 +155,16 @@ If receiving external files isn’t allowed, then users in your organization SHO
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
   - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
 
+#### GWS.DRIVEDOCS.1.12v0.6
+If external sharing files externally or recieving external files is allowed, then the "Highlight External Files" setting SHALL be enabled.
+
+- _Rationale:_ If users are able to  share files externally and/or recieve files owned by an external individual, enabling this setting ensures that users are made aware that external users can see/edit the document via the label.
+- _Last modified:_ December 2025
+- Insert NIST Mapping Here
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1537: Transfer Data to Cloud Account](https://attack.mitre.org/techniques/T1537/)
+
 
 ### Resources
 

--- a/scubagoggles/baselines/drive.md
+++ b/scubagoggles/baselines/drive.md
@@ -211,7 +211,7 @@ To configure the settings for Sharing options:
 #### GWS.DRIVEDOCS.1.9v0.6 Instructions
 1.  Select **Sharing settings -\> Highlight External Files**
 2.  Select **Highlight external files**
-3.  Check the **Highlight external Files** box to turn on the indicator.
+3.  Check the **Mark files shared or owned externally as "external" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.
 4.  Select **Save**.
 
 #### GWS.DRIVEDOCS.1.10v0.6 Instructions

--- a/scubagoggles/baselines/drive.md
+++ b/scubagoggles/baselines/drive.md
@@ -210,8 +210,8 @@ To configure the settings for Sharing options:
 
 #### GWS.DRIVEDOCS.1.9v0.6 Instructions
 1.  Select **Sharing settings -\> Highlight External Files**.
-3.  Check the **Mark files shared or owned externally as "external" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.
-4.  Select **Save**.
+2.  Check the **Mark files shared or owned externally as "external" to indicate that content may be viewable outside your organization. Applies to Drive, Docs, Sheets, Slides, Drawings, and Vids.** box to turn on the indicator.
+3.  Select **Save**.
 
 #### GWS.DRIVEDOCS.1.10v0.6 Instructions
 1.  Select **Sharing settings -\> Sharing options**


### PR DESCRIPTION
## 🗣 Description ##

Updated Drive_Docs Policy 1.9 to be consistent with Admin Console wording. Closes #847 

### 💭 Motivation and context

The wording of the policy did not match what is in the admin Console

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

Update wording.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [x] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
