### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/cisagov/ScubaGoggles)
+
 ![ScubaGoggles Logo](https://github.com/cisagov/ScubaGoggles/raw/main/docs/images/ScubaGoggles%20GitHub%20Graphic%20v2.jpg)
 
 


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/cisagov/ScubaGoggles) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.