### PR TITLE
Unit Tests Throw Error -o Flag

### DIFF
--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -108,7 +108,7 @@ for b in args.baselines:
             for c in command_list: command_display += f'\"{c}\" '
             print(command_display)
 
-            subprocess.run(command.split(), check=False)
+            subprocess.run(command_list, check=False)
     else:
         print(f"\n==== Testing {b} ====")
         command = f'{OPA_EXE}\" test\" {rego_dir}\" {test_dir}/Rego/{b}'

--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -102,7 +102,12 @@ for b in args.baselines:
             if V_FLAG:
                 command += f'\"{V_FLAG}'
             command_list = [s.strip() for s in command.split("\"")]
-            print(command_list)
+            
+            # for the sake of displaying the command
+            command_display = ""
+            for c in command_list: command_display += f'\"{c}\" '
+            print(command_display)
+
             subprocess.run(command.split(), check=False)
     else:
         print(f"\n==== Testing {b} ====")
@@ -111,5 +116,11 @@ for b in args.baselines:
         if V_FLAG:
             command += f'\"{V_FLAG}'
         command_list = [s.strip() for s in command.split("\"")]
-        print(command_list)
+        # for the sake of displaying the command
+
+        # for the sake of displaying the command
+        command_display = ""
+        for c in command_list: command_display += f'\"{c}\" '
+        print(command_display)
+
         subprocess.run(command_list, check=False)

--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -3,8 +3,11 @@ run_unit_tests.py runs the rego unit tests
 
 Currently runs non-verbosely
 """
+import os
 import subprocess
 import argparse
+
+from scubagoggles.config import UserConfig
 
 from pathlib import Path
 from sys import platform
@@ -49,9 +52,11 @@ parser.add_argument('-c', '--controls', type = str, nargs="+",
 default=[], help="Space-separated list of control group numbers to test within a specific baseline."
 "Can only be used when a single baseline is specified. By default all are run.")
 
-parser.add_argument('-o', '--opapath', type=str, default='../../..', metavar='',
+# obtain the default OPA executable location from UserSetup()
+opa_dir = UserConfig().opa_dir or "../../.." 
+parser.add_argument('-o', '--opapath', type=str, default=opa_dir, metavar='',
 help='The relative path to the directory containing the OPA executable. ' +
-    'Defaults to "../../.." the current executing directory.')
+    'Defaults to the default location of the opa executable from UserConfig.')
 
 parser.add_argument('-v', action='store_true',
 help='Verbose flag, passed to opa, increases output.')
@@ -91,12 +96,20 @@ for b in args.baselines:
         for c in args.controls:
             print(f"\n==== Testing {b} control {c} ====")
             c = c.zfill(2)
-            command = (f'{OPA_EXE} test {rego_dir} '
-                       f'{test_dir}/Rego/{b}/{b}{c}_test.rego {V_FLAG}')
-            print(command)
+            command = f'{OPA_EXE}\" test\" {rego_dir}\"'
+            command += f'{test_dir}/Rego/{b}/{b}{c}_test.rego'
+            # only append if V_FLAG is set
+            if V_FLAG:
+                command += f'\"{V_FLAG}'
+            command_list = [s.strip() for s in command.split("\"")]
+            print(command_list)
             subprocess.run(command.split(), check=False)
     else:
         print(f"\n==== Testing {b} ====")
-        command = f'{OPA_EXE} test {rego_dir} {test_dir}/Rego/{b} {V_FLAG}'
-        print(command)
-        subprocess.run(command.split(), check=False)
+        command = f'{OPA_EXE}\" test\" {rego_dir}\" {test_dir}/Rego/{b}'
+        # only append if V_FLAG is set
+        if V_FLAG:
+            command += f'\"{V_FLAG}'
+        command_list = [s.strip() for s in command.split("\"")]
+        print(command_list)
+        subprocess.run(command_list, check=False)

--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -7,6 +7,7 @@ import subprocess
 import argparse
 
 from scubagoggles.config import UserConfig
+from scubagoggles.run_rego import find_opa
 
 from pathlib import Path
 from sys import platform
@@ -52,7 +53,7 @@ default=[], help="Space-separated list of control group numbers to test within a
 "Can only be used when a single baseline is specified. By default all are run.")
 
 # obtain the default OPA executable location from UserSetup()
-opa_dir = UserConfig().opa_dir or "../../.." 
+opa_dir = UserConfig().opa_dir
 parser.add_argument('-o', '--opapath', type=str, default=opa_dir, metavar='',
 help='The relative path to the directory containing the OPA executable. ' +
     'Defaults to the default location of the opa executable from UserConfig.')
@@ -74,20 +75,7 @@ if args.v:
 
 #Get OPA Path from command line args
 opa_path = args.opapath
-OPA_EXE = ""
-command = []
-if platform == 'win32':
-    OPA_EXE = f'{opa_path}/opa_windows_amd64.exe'
-elif platform == 'darwin':
-    OPA_EXE = f'{opa_path}/opa_darwin_amd64'
-elif platform in ('linux', 'linux2'):
-    OPA_EXE = f'{opa_path}opa_linux_amd64_static'
-
-if not OPA_EXE or not Path(OPA_EXE).exists():
-    OPA_EXE = f'{opa_path}/opa'
-
-if not Path(OPA_EXE).exists():
-    raise FileNotFoundError(f'? {OPA_EXE}: OPA executable not found')
+OPA_EXE = find_opa(opa_path)
 
 for b in args.baselines:
     b = b.lower()

--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -3,7 +3,6 @@ run_unit_tests.py runs the rego unit tests
 
 Currently runs non-verbosely
 """
-import os
 import subprocess
 import argparse
 

--- a/scubagoggles/Testing/Unit/run_unit_tests.py
+++ b/scubagoggles/Testing/Unit/run_unit_tests.py
@@ -116,7 +116,6 @@ for b in args.baselines:
         if V_FLAG:
             command += f'\"{V_FLAG}'
         command_list = [s.strip() for s in command.split("\"")]
-        # for the sake of displaying the command
 
         # for the sake of displaying the command
         command_display = ""


### PR DESCRIPTION
## 🗣 Description ##

This Pull Request implements some changes regarding how the OPA Path command line default is handled and how the Unit tests are executed.

Instead of the "three directories up" default ('../../..') location to look for the OPA executable, it is first replaced with the default configured path specified in the UserConfig() class (default config set up for Scuba Command-line Parser).  The original issue came down to the fact that the OPA executable is no longer installed there ('../../..'), so this fix addresses that.

Secondly, this Pull request fixes an additional bug found regarding how OPA Executable test commands (see screenshot below) are executed. There was a bug which was splitting whitespace in directory paths, causing errors regarding the command interpreter interpreting partial directories as arguments (a syntax error). This fix also replaces the original split() of the entire Rego command so that the whitespaces inside full directories are disregarded.

Closes #648

### 💭 Motivation and context

These changes make the Unit Test Python Script more flexible to run and keep up with default paths for the OPA executable.

## 📷 Screenshots (if appropriate) ##

Command line Bug (lines marked in red)

<img width="921" height="707" alt="bugscubacommandunittests" src="https://github.com/user-attachments/assets/829c5778-d0d0-4b9f-9ec3-8ed6b21d7f48" />



## 🧪 Testing

Newly Bug When output is correctly specified:

```
...
==== Testing classroom ====
C:\Users\USER\.scubagoggles/opa_windows_amd64.exe test C:\Users\USER\My Folder\ScubaGoggles\scubagoggles\rego C:\Users\USER\My Folder\ScubaGoggles\scubagoggles\Testing\Unit/Rego/classroom
4 errors occurred during loading:
CreateFile C:\Users\USER\My: The system cannot find the file specified.
CreateFile Folder\ScubaGoggles\scubagoggles\rego: The system cannot find the file specified.
CreateFile C:\Users\USER\My: The system cannot find the file specified.
CreateFile Folder\ScubaGoggles\scubagoggles\Testing\Unit/Rego/classroom: The system cannot find the file specified.
```

After quote-splitting and leading/trailing whitespace stripping:

```
...
==== Testing classroom ====
"C:\Users\USER\.scubagoggles/opa_windows_amd64.exe" "test" "C:\Users\USER\My Folder\ScubaGoggles\scubagoggles\rego" "C:\Users\USER\My Folder\ScubaGoggles\scubagoggles\Testing\Unit/Rego/classroom"
PASS: 12/12
```

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.