### PR TITLE
added logic to parse DMARC records and count rua and ruf fields

### DIFF
--- a/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
@@ -387,7 +387,12 @@ test_DMARCAgencyPOC_Correct_V1 if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics@dhs.gov",
+                    ])
                 ]
             }
         ],
@@ -409,13 +414,23 @@ test_DMARCAgencyPOC_Correct_V2 if {
             {
                 "domain": "test1.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics@dhs.gov",
+                    ])
                 ]
             },
             {
                 "domain": "test2.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics@dhs.gov",
+                    ])
                 ]
             }
         ],
@@ -437,7 +452,12 @@ test_DMARCAgencyPOC_Incorrect_V1 if {
             {
                 "domain": "test1.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics@dhs.gov",
+                    ])
                 ]
             },
             {
@@ -552,7 +572,12 @@ test_DMARCAgencyPOC_Incorrect_DuplicateRuaTags if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov; rua=mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov; ",
+                        "rua=mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics@dhs.gov",
+                    ])
                 ]
             }
         ],
@@ -574,7 +599,13 @@ test_DMARCAgencyPOC_Incorrect_DuplicateRufTags if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics1@dhs.gov; ruf=mailto:forensics2@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics1@dhs.gov; ",
+                        "ruf=mailto:forensics2@dhs.gov",
+                    ])
                 ]
             }
         ],
@@ -618,7 +649,12 @@ test_DMARCAgencyPOC_Incorrect_RufNotMailto if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=https://dhs.gov/forensics"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=mailto:DMARC@hq.dhs.gov, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=https://dhs.gov/forensics",
+                    ])
                 ]
             }
         ],
@@ -640,7 +676,12 @@ test_DMARCAgencyPOC_Incorrect_RuaNotMailto if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=https://dhs.gov/aggregateReporting, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics2@dhs.gov"
+                    concat("", [
+                        "v=DMARC1; p=reject; pct=100; ",
+                        "rua=https://dhs.gov/aggregateReporting, ",
+                        "mailto:reports@dmarc.cyber.dhs.gov; ",
+                        "ruf=mailto:forensics2@dhs.gov",
+                    ])
                 ]
             }
         ],

--- a/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
@@ -387,7 +387,7 @@ test_DMARCAgencyPOC_Correct_V1 if {
             {
                 "domain": "test.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
                 ]
             }
         ],
@@ -409,13 +409,13 @@ test_DMARCAgencyPOC_Correct_V2 if {
             {
                 "domain": "test1.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
                 ]
             },
             {
                 "domain": "test2.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
                 ]
             }
         ],
@@ -437,7 +437,7 @@ test_DMARCAgencyPOC_Incorrect_V1 if {
             {
                 "domain": "test1.name",
                 "rdata": [
-                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
                 ]
             },
             {

--- a/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
@@ -499,4 +499,158 @@ test_DMARCAgencyPOC_Incorrect_V3 if {
         MultipleWarning,
         DNSLink])
 }
+
+test_DMARCAgencyPOC_Incorrect_MissingRuf if {
+    # Test DMARC when it's missing a RUF value
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_MissingRua if {
+    # Test DMARC when it's missing a RUA value
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; ruf=mailto:forensics@dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_DuplicateRuaTags if {
+    # Test DMARC record if there's multiple RUA fields in the DMARC record
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov; rua=mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_DuplicateRufTags if {
+    # Test DMARC record if there's multiple RUF fields in the DMARC record
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics1@dhs.gov; ruf=mailto:forensics2@dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_OneRuaAddress if {
+    # Test DMARC record if there's only one RUA address
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov; ruf=mailto:forensics@dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_RufNotMailto if {
+    # Test DMARC record RUF field if it's not formed correctly (not "mailto")
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=mailto:DMARC@hq.dhs.gov, mailto:reports@dmarc.cyber.dhs.gov; ruf=https://dhs.gov/forensics"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
+
+test_DMARCAgencyPOC_Incorrect_RuaNotMailto if {
+    # Test DMARC record RUA field if it's not formed correctly (not "mailto")
+    PolicyId := GmailId4_4
+    Output := tests with input as {
+        "dmarc_records": [
+            {
+                "domain": "test.name",
+                "rdata": [
+                    "v=DMARC1; p=reject; pct=100; rua=https://dhs.gov/aggregateReporting, mailto:reports@dmarc.cyber.dhs.gov; ruf=mailto:forensics2@dhs.gov"
+                ]
+            }
+        ],
+        "domains": ["test.name"]
+    }
+
+    RuleOutput := [Result | some Result in Output; Result.PolicyId == PolicyId]
+    count(RuleOutput) == 1
+    not RuleOutput[0].RequirementMet
+    not RuleOutput[0].NoSuchEvent
+    RuleOutput[0].ReportDetails == concat(" ", ["1 of 1 agency domain(s) found in violation: test.name.", DNSLink])
+}
 #--

--- a/scubagoggles/rego/Gmail.rego
+++ b/scubagoggles/rego/Gmail.rego
@@ -277,8 +277,52 @@ GmailId4_4 := utils.PolicyIdWithSuffix("GWS.GMAIL.4.4")
 DomainsWithAgencyContact contains DmarcRecord.domain if {
     some DmarcRecord in input.dmarc_records
     some Rdata in DmarcRecord.rdata
-    count(split(Rdata, "@")) >= 3
     DmarcRecord.domain in DomainsWithDmarc
+
+    # splits the DMARC record into semicolon-separated tags
+    parts := [trim(part, " ") |
+        some part in split(Rdata, ";")
+        trim(part, " ") != ""
+    ]
+
+    # collects any DMARC record tag with "rua="
+    ruaParts := [part |
+        some part in parts
+        startswith(lower(part), "rua=")
+    ]
+
+    # collects any DMARC record tag with "ruf="
+    rufParts := [part |
+        some part in parts
+        startswith(lower(part), "ruf=")
+    ]
+
+    # requires exactly 1 rau and 1 ruf field per DMARC record
+    count(ruaParts) == 1
+    count(rufParts) == 1
+
+    # takes each "rua=" tag and splits them on each comma
+    # then only keeps a record that starts with "mailto:"
+    ruaAddrs := [addr |
+        some part in ruaParts
+        values := split(split(part, "=")[1], ",")
+        some addr in values
+        startswith(lower(trim(addr, " ")), "mailto:")
+    ]
+
+    # takes each "ruf=" tag and splits them on each comma
+    # then only keeps a record that starts with "mailto:"
+    rufAddrs := [addr |
+        some part in rufParts
+        values := split(split(part, "=")[1], ",")
+        some addr in values
+        startswith(lower(trim(addr, " ")), "mailto:")
+    ]
+
+    # requires >= 2 rua tags that are correctly formed
+    # requires >= 1 ruf tag that is correctly formed 
+    count(ruaAddrs) >= 2
+    count(rufAddrs) >= 1
 }
 
 tests contains {

--- a/scubagoggles/rego/Gmail.rego
+++ b/scubagoggles/rego/Gmail.rego
@@ -297,7 +297,7 @@ DomainsWithAgencyContact contains DmarcRecord.domain if {
         startswith(lower(part), "ruf=")
     ]
 
-    # requires exactly 1 rau and 1 ruf field per DMARC record
+    # requires exactly 1 rua and 1 ruf field per DMARC record
     count(ruaParts) == 1
     count(rufParts) == 1
 


### PR DESCRIPTION
## 🗣 Description ##

Change the logic in the gmail rego so that rather than checking for the amount of @ symbols to determine how many emails were assigned to a DMARC record, rego performs a deeper review of the DMARC record. The policy now determines if the DMARC record is correctly formed with 1 "rua" tag, 1 "ruf" tag, and the "rua" tag contains at least two "mailto" addresses. 

### 💭 Motivation and context

This closes Issue #170. 

This updates the logic to meet the baseline requirements. 

## 🧪 Testing

Tested using the domains already in the test workspace. I modified the policy checks (e.g., `count(ruaAddrs) >= 2`) to see if the `rua` and `ruf` tags are being counted correctly. For example: 

`v​=​D​M​A​R​C​1​;​ ​p​=​r​e​j​e​c​t​;​ ​r​u​a​=​m​a​i​l​t​o​:a​@​example​.org;​ ​p​c​t​=​1​0​0​;​ ​r​u​f​=​m​a​i​l​t​o​:​b​@​example.org` will pass `count(ruaAddrs) >= 1` but won't pass `count(ruaAddrs) >= 2`

I also tested the rego with custom JSON that was passed via CLI. I created two JSON files, one that should pass and one that should fail: 

Passing JSON: [input-pass.json](https://github.com/user-attachments/files/26761855/input-pass.json)

Failing JSON: [input-fail.json](https://github.com/user-attachments/files/26761862/input-fail.json)

The command to run the rego against the JSON (run while in scubagoggles/rego): `opa eval -f pretty -i <input-fail.json or input-pass.json> -d . 'count(data.gmail.AllDomains - data.gmail.DomainsWithAgencyContact) == 0'`. Only put one json file in the directory at a time - multiple json files in `scubagoggles/rego` will cause opa to fail in the CLI. 

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
