### PR TITLE
Updated the multiple DMARC record warning

### DIFF
--- a/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/gmail/gmail04_test.rego
@@ -1,7 +1,10 @@
 package gmail
 import future.keywords
 
-MultipleWarning := "1 domain(s) have multiple DMARC records: test.name."
+MultipleWarning := concat("", [
+    "1 domain(s) have multiple DMARC records and will fail the policy check: ",
+    "test.name. DMARC records should only have one record according to RFC 7489."
+])
 #
 # GWS.GMAIL.4.1
 #--

--- a/scubagoggles/rego/Gmail.rego
+++ b/scubagoggles/rego/Gmail.rego
@@ -173,9 +173,9 @@ MultiDmarcWarning := Warning if {
     Warning := concat("", [
         " ",
         format_int(count(DomainsWithMultipleDmarc), 10),
-        " domain(s) have multiple DMARC records: ",
+        " domain(s) have multiple DMARC records and will fail the policy check: ",
         concat(", ", DomainsWithMultipleDmarc),
-        ". "
+        ". DMARC records should only have one record according to RFC 7489."
     ])
 }
 

--- a/scubagoggles/rego/Gmail.rego
+++ b/scubagoggles/rego/Gmail.rego
@@ -175,7 +175,7 @@ MultiDmarcWarning := Warning if {
         format_int(count(DomainsWithMultipleDmarc), 10),
         " domain(s) have multiple DMARC records and will fail the policy check: ",
         concat(", ", DomainsWithMultipleDmarc),
-        ". DMARC records should only have one record according to RFC 7489."
+        ". DMARC records should only have one record according to RFC 7489. "
     ])
 }
 


### PR DESCRIPTION
## 🗣 Description ##

Updated the warning message for when multiple DMARC records are detected to be more descriptive. 

### 💭 Motivation and context

Users may not know that DMARC records should not have multiple DMARC records according to RFC 7489. This updates the warning message so that it's more assertive that it will fail the policy check. This will close Issue #999. 

## 🧪 Testing

Ran `scubagoggles gws` to check that the warning message correctly populated. 

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
