### PR TITLE
974: Rename reportredaction parameter

### DIFF
--- a/docs/usage/Parameters.md
+++ b/docs/usage/Parameters.md
@@ -92,7 +92,7 @@ Here is an example using `--baselines`:
 
 ```powershell
 # Assess two products
-scubagoggles gws --baselines chat, meet 
+scubagoggles gws --baselines chat, meet
 ```
 >**Note**: baselines are separated by commas.
 
@@ -190,7 +190,7 @@ Here is an example using `--customerid`:
 scubagoggles gws --customerid <customer-id>
 ```
 
-## OPA Path 
+## OPA Path
 
 **- --opapath** is the location of the folder that contains the Open Policy Agent (OPA) policy engine executable file. Defaults to ~/.scubagoggles/.
 
@@ -434,7 +434,7 @@ Here is an example using `--numberofuuidcharacterstotruncate`:
 # Truncate the UUID at the end of OutJsonFileName by 18 characters
 scubagoggles gws --numberofuuidcharacterstotruncate 18
 ```
-## Debug OPA 
+## Debug OPA
 
 **--debug** This switch is used to print debugging information for OPA.
 
@@ -464,9 +464,9 @@ scubagoggles gws --debug
 # View the HTML report in dark mode
 scubagoggles gws --darkmode
 ```
-## Report Redaction
+## Testing Mode
 
-**--reportredaction** enables identification information redaction styles for the report output.
+**--cicdtestingmode** enables identification information redaction styles for the report output.
 
 | Parameter   | Value    |
 |-------------|----------|
@@ -477,13 +477,13 @@ scubagoggles gws --darkmode
 
 ```powershell
 # Enable identification information redaction styles for the report output
-scubagoggles gws --reportredaction
+scubagoggles gws --cicdtestingmode
 ```
 ## Preferred DoH Servers
 
 **--preferreddohservers**  IP addresses or domain names of DoH servers that should be used to retrieve any TXT records, should the traditional DNS queries fail, required by specific SCuBA policies. See [PreferredDnsResolvers](#preferreddnsresolvers) for the list of applicable policies.
 
-Optional; If not provided, the DoH query will use a default list of DoH servers:"cloudflare-dns.com", "2606:4700:4700::1111", "1.1.1.1". 
+Optional; If not provided, the DoH query will use a default list of DoH servers:"cloudflare-dns.com", "2606:4700:4700::1111", "1.1.1.1".
 
 | Parameter   | Value                                               |
 |-------------|-----------------------------------------------------|
@@ -498,7 +498,7 @@ Here is an example using `--preferreddohservers`:
 scubagoggles gws --preferreddohservers 8.8.8.8 cloudfare-dns.com 2606:4700:4700::1111
 ```
 
-## Run cache mode 
+## Run cache mode
 
 **--runcached** switch when added will run the tool in "RunCached mode". When combined with --skipexport allows the user to skip authentication and provider export.
 
@@ -511,7 +511,7 @@ scubagoggles gws --preferreddohservers 8.8.8.8 cloudfare-dns.com 2606:4700:4700:
 
 ```powershell
 # run the tool in "RunCached mode"
-scubagoggles gws --runcached 
+scubagoggles gws --runcached
 ```
 ## Skip Export
 

--- a/docs/usage/Parameters.md
+++ b/docs/usage/Parameters.md
@@ -464,21 +464,6 @@ scubagoggles gws --debug
 # View the HTML report in dark mode
 scubagoggles gws --darkmode
 ```
-## Testing Mode
-
-**--cicdtestingmode** enables identification information redaction styles for the report output.
-
-| Parameter   | Value    |
-|-------------|----------|
-| Optional    | Yes      |
-| Datatype    | Boolean  |
-| Default     | n/a      |
-| Config File | Yes      |
-
-```powershell
-# Enable identification information redaction styles for the report output
-scubagoggles gws --cicdtestingmode
-```
 ## Preferred DoH Servers
 
 **--preferreddohservers**  IP addresses or domain names of DoH servers that should be used to retrieve any TXT records, should the traditional DNS queries fail, required by specific SCuBA policies. See [PreferredDnsResolvers](#preferreddnsresolvers) for the list of applicable policies.

--- a/scubagoggles/Testing/Functional/SmokeTests/smoke_test.py
+++ b/scubagoggles/Testing/Functional/SmokeTests/smoke_test.py
@@ -43,7 +43,7 @@ class SmokeTest:
 
         svc_account_option = (f' --subjectemail {subjectemail}' if subjectemail
                               else '')
-        command = f'scubagoggles gws{svc_account_option} -rr true --quiet '
+        command = f'scubagoggles gws{svc_account_option} -ctm true --quiet '
 
         try:
             subprocess.run(command, shell=True, check=True)

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -71,8 +71,8 @@ def get_gws_args(parser: argparse.ArgumentParser, user_config: UserConfig):
                         choices=('true', 'false'),
                         help='Enable dark mode')
 
-    parser.add_argument('--reportredaction',
-                        '-rr',
+    parser.add_argument('--cicdtestingmode',
+                        '-ctm',
                         metavar='<report-redaction>',
                         choices=('true', 'false'),
                         help='Enable report redaction')

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -75,7 +75,7 @@ def get_gws_args(parser: argparse.ArgumentParser, user_config: UserConfig):
                         '-ctm',
                         metavar='<testing-mode>',
                         choices=('true', 'false'),
-                        help='Enable testing mode for reports')
+                        help=argparse.SUPPRESS)
 
     help_msg = ('Access token string to be used in lieu of a credentials file. '
                 'If provided, will take precendence over the credentials file. '

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -73,9 +73,9 @@ def get_gws_args(parser: argparse.ArgumentParser, user_config: UserConfig):
 
     parser.add_argument('--cicdtestingmode',
                         '-ctm',
-                        metavar='<report-redaction>',
+                        metavar='<testing-mode>',
                         choices=('true', 'false'),
-                        help='Enable report redaction')
+                        help='Enable testing mode for reports')
 
     help_msg = ('Access token string to be used in lieu of a credentials file. '
                 'If provided, will take precendence over the credentials file. '

--- a/scubagoggles/orchestrator.py
+++ b/scubagoggles/orchestrator.py
@@ -501,9 +501,9 @@ class Orchestrator:
             raw_data.update({'scuba_config': args_dict})
         return raw_data
 
-    def _redact_lhci_reports(self, reportredaction, outputpath) -> None:
+    def _redact_lhci_reports(self, cicdtestingmode, outputpath) -> None:
         """ Redact PII on the lighthouse ci reports """
-        if reportredaction == 'true':
+        if cicdtestingmode == 'true':
             # Lighthouse Config
             lighthouserc_json = Path(__file__).parent / 'lighthouserc.json'
             shutil.copy(lighthouserc_json, outputpath)
@@ -521,9 +521,9 @@ class Orchestrator:
         """
 
         # pylint: disable=line-too-long
-        baselines,outputpath, fullnamesdict, outputregofilename, outputproviderfilename, darkmode, reportredaction, quiet = itemgetter(
+        baselines,outputpath, fullnamesdict, outputregofilename, outputproviderfilename, darkmode, cicdtestingmode, quiet = itemgetter(
             "baselines","outputpath","fullnamesdict","outputregofilename",
-            "outputproviderfilename", "darkmode", "reportredaction", "quiet"
+            "outputproviderfilename", "darkmode", "cicdtestingmode", "quiet"
             )(self.args_dict)
 
         # Make the report output folders
@@ -626,7 +626,7 @@ class Orchestrator:
                 reporter.rego_json_to_ind_reports(test_results_data,
                                                   outputpath,
                                                   darkmode,
-                                                  reportredaction)
+                                                  cicdtestingmode)
             baseline_product_summary = {product: stats_and_data[product][0]}
             baseline_product_results_json = {
                 product: stats_and_data[product][1]}
@@ -667,7 +667,7 @@ class Orchestrator:
         self._dump_report_files(outputpath, out_jsonfile, total_output)
 
         # Check for Test Run
-        self._redact_lhci_reports(reportredaction, outputpath)
+        self._redact_lhci_reports(cicdtestingmode, outputpath)
 
         # Delete the ProviderOutput file as it's now encapsulated in the
         # ScubaResults file
@@ -693,7 +693,7 @@ class Orchestrator:
                                                          tenant_info,
                                                          report_uuid,
                                                          darkmode,
-                                                         reportredaction)
+                                                         cicdtestingmode)
         report_path.write_text(front_page_html, encoding='utf-8')
 
         # suppress opening the report in the browser

--- a/scubagoggles/reporter/scripts/main.js
+++ b/scubagoggles/reporter/scripts/main.js
@@ -303,7 +303,7 @@ const applyScopeAttributes = () => {
 
 /**
  * Apply redaction to identification information in reports
- * based on the --reportredaction (-rr) CLI arg
+ * based on the --cicdtestingmode (-ctm) CLI arg
  */
 function redaction() {
     const cliElement = document.getElementById("sgr_settings");


### PR DESCRIPTION
## 🗣 Description ##

Renaming the `reportreduction`to avoid confusion with it's functionality within report testing.

### 💭 Motivation and context

Resolves #974 


<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

Generate report by manually calling scuba.py gws --cicdtestingmode true
Generated report by manually calling scubagoggles gws -ctm true
Viewed report in Chrome

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [ ] This PR has an informative and human-readable title.
- [ ] Changes are limited to a single goal - *eschew scope creep!*
- [ ] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [ ] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [ ] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
