### PR TITLE
Add Logging to File Capability

### DIFF
--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -459,6 +459,12 @@ def dive():
                         help='Level for message log '
                         f'(default: {default_log_level})')
 
+    parser.add_argument('--outputlog',
+                        '-o',
+                        metavar='<file>',
+                        type=path_parser,
+                        help='File for writing log messages')
+
     subparsers = parser.add_subparsers(description='valid subcommands:',
                                        help='<subcommand> -h for help')
 
@@ -494,7 +500,6 @@ def dive():
     get_version_args(setup_parser)
 
     scuba_parser = ScubaArgumentParser(parser)
-    args = scuba_parser.parse_args_with_config()
 
     # When trapping exceptions to suppress tracebacks (which users don't need
     # to see for obvious failures not related to the code), make sure the
@@ -503,6 +508,7 @@ def dive():
     error = False
 
     try:
+        args = scuba_parser.parse_args_with_config()
         args.dispatch(args)
     except NotADirectoryError as nad:
         print(f'\n{nad}')

--- a/scubagoggles/scuba_argument_parser.py
+++ b/scubagoggles/scuba_argument_parser.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import yaml
 
+from scubagoggles.orchestrator import UserRuntimeError
 from scubagoggles.reporter.md_parser import MarkdownParser
 from scubagoggles.utils import path_parser
 
@@ -71,8 +72,7 @@ class ScubaArgumentParser:
         """
         args = self.parse_args()
 
-        logging.basicConfig(format='(%(levelname)s): %(message)s',
-                            level=log_level(args.log))
+        self._start_logging(args)
 
         if 'breakglassaccounts' not in args or args.breakglassaccounts is None:
             args.breakglassaccounts = []
@@ -286,3 +286,55 @@ class ScubaArgumentParser:
                 continue
             validated_exclusions.append(validated_exclusion)
         args.sitesexclusions = validated_exclusions
+
+    @staticmethod
+    def _start_logging(args: argparse.Namespace) -> None:
+
+        """Initializes the logging for ScubaGoggles.  There are two command
+        line arguments that apply to logging: the minimum severity level for
+        logged messages and an optional output file.
+
+        Messages are always written to the standard output stream, and
+        optionally to a log file.  Users can suppress messages to standard
+        output either by specifying the appropriate severity or by
+        redirecting standard output.
+
+        :param argparse.Namespace args: command line arguments.
+        """
+
+        console_handler = logging.StreamHandler()
+
+        formatter = logging.Formatter('{levelname:8s} {message}', style='{')
+
+        console_handler.setFormatter(formatter)
+
+        log_handlers = [console_handler]
+
+        if args.outputlog:
+
+            # Log messages will be written to the given file.  Messages
+            # written to the file contain a bit more information about
+            # where they originated for debugging.
+
+            try:
+                if args.outputlog.is_dir():
+                    raise UserRuntimeError(f'? {args.outputlog} - '
+                                           'is a directory')
+
+                file_handler = logging.FileHandler(args.outputlog,
+                                                   mode='w',
+                                                   encoding='utf-8')
+            except PermissionError as pe:
+                raise UserRuntimeError(f'? {args.outputlog} - cannot create log'
+                                       ' file due to permission error') from pe
+
+            file_format = ('{levelname} [{module}:{funcName}:{lineno}] '
+                           '{message}')
+
+            formatter = logging.Formatter(file_format, style='{')
+
+            file_handler.setFormatter(formatter)
+
+            log_handlers.append(file_handler)
+
+        logging.basicConfig(level=log_level(args.log), handlers=log_handlers)


### PR DESCRIPTION
## 🗣 Description ##

ScubaGoggles currently writes all log messages to the standard output stream.  This change allows the same log messages to be written to a file using the global `--outputlog` option.  When this option is specified, a new (empty) file is created with the file specification given in the option.

When the `--outputlog` option is used, log messages are written to **both** the standard output stream and the file.  Users may suppress messages to standard output by redirecting the output to a "null" device.

Both the `--log` and `--outputlog` options are not documented in the user's guide.  I considered adding this to the "troubleshooting" section, but decided not to add it.  Both options are available in the help and are really relevant to the development team.  There may be some need for users to use these options to assist in debugging, but they'd be doing this at the development team's direction.

This is the help for the options:

```
options:
  -h, --help            show this help message and exit
  --log, -l {d,i,w,e,c,debug,info,warning,error,critical}
                        Level for message log (default: warning)
  --outputlog, -o <file>
                        File for writing log messages
```

Note that these are **global** options, which mean they apply to all `scubagoggles` commands and are placed **before** the command (e.g., `scubagoggles --log debug --outputlog scubagoggles.log gws -b commoncontrols`).

Closes #438

## 🧪 Testing

This has been tested both on WIndows and linux for the successful case (normal log file), as well as exception cases (specifying a directory or file that will yield permission errors).


## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [X] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels have been added.
- [X] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
