### PR TITLE
ci: add least-privilege permissions to read-only workflows

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -3,6 +3,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/run_link_checker_for_md_edits.yml
+++ b/.github/workflows/run_link_checker_for_md_edits.yml
@@ -3,6 +3,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/run_opa_tests.yml
+++ b/.github/workflows/run_opa_tests.yml
@@ -5,6 +5,9 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   Run-OPA-Tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Three workflows were missing explicit `permissions:` blocks and were inheriting the repository default token — broader than necessary. This PR adds `permissions: contents: read` to each, following the principle of least privilege.

| Workflow | Permissions before | Permissions after |
|---|---|---|
| `pylint.yml` | inherited default | `contents: read` |
| `run_link_checker_for_md_edits.yml` | inherited default | `contents: read` |
| `run_opa_tests.yml` | inherited default | `contents: read` |

## Context

PR #1048 addressed this same issue for `run_link_checker_cron_job.yml`. After reviewing the other workflows, three additional files have the same gap. This PR extends that fix to cover them.

Two other workflows (`run_release.yml`, `publish_to_pypi.yml`) have multi-job setups with partial job-level permissions — those are left intentionally out of scope here as they require more careful review.

This is flagged by [OpenSSF Scorecard — Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).