### PR TITLE
Skip disabled Gmail spam override allow lists when scanning for domains

### DIFF
--- a/scubagoggles/Testing/Unit/Python/parsers/test_gmail_rules_parser.py
+++ b/scubagoggles/Testing/Unit/Python/parsers/test_gmail_rules_parser.py
@@ -6,7 +6,28 @@ from pathlib import Path
 from scubagoggles.parsers.gmail_rules_parser import GmailRulesParser
 from scubagoggles.Testing.Unit.Python.test_policy_api import CommonMethods
 
-# pylint: disable=too-few-public-methods
+
+def _spam_override_section(enabled: bool):
+
+    """Builds a minimal spam override section with one "hide warning banner"
+    allow list that contains a domain.  The enable flag is set per the
+    argument so both the disabled and enabled cases can be exercised.
+    """
+
+    return {
+        'spamOverride': [
+            {
+                'description': 'TestList',
+                'hideWarningBannerFromSelectedSenders': enabled,
+                'hideWarningBannerSenderAllowlist': [
+                    {
+                        'name': 'MyAllowList',
+                        'list': ['evil.example.com']
+                    }
+                ]
+            }
+        ]
+    }
 
 
 class TestGmailRulesParser:
@@ -37,3 +58,32 @@ class TestGmailRulesParser:
                 policies = test_data['policies']
                 gmail_parser = GmailRulesParser(policy_api, policies)
                 assert gmail_parser._address_lists == test_data['results']
+
+    def test_gmail_domain_addr_disabled_allow_list(self):
+
+        """A disabled spam override allow list must be skipped, even when it
+        contains a domain, so no "domains found" marker is emitted.
+        """
+
+        # Bypass __init__, which needs a live Policy API; only the
+        # _gmail_domain_addr method is under test here.
+        parser = object.__new__(GmailRulesParser)
+        section = _spam_override_section(enabled = False)
+
+        parser._gmail_domain_addr(section)
+
+        assert 'warningDomainsFound' not in section
+
+    def test_gmail_domain_addr_enabled_allow_list(self):
+
+        """An enabled allow list with a domain still emits the marker, so the
+        disabled-list fix doesn't suppress real findings.
+        """
+
+        parser = object.__new__(GmailRulesParser)
+        section = _spam_override_section(enabled = True)
+
+        parser._gmail_domain_addr(section)
+
+        assert section['warningDomainsFound'] == \
+            '{TestList: [MyAllowList: (evil.example.com)]}'

--- a/scubagoggles/parsers/gmail_rules_parser.py
+++ b/scubagoggles/parsers/gmail_rules_parser.py
@@ -170,7 +170,7 @@ class GmailRulesParser:
 
             for override in spam_override_section['spamOverride']:
 
-                if not enable:
+                if not override.get(enable):
                     continue
 
                 domains_list = []


### PR DESCRIPTION
A spam override allow list that the admin has disabled still gets parsed for domains, so if it contains a domain it sets warningDomainsFound (or senderDomainsFound) and the org unit gets flagged against GWS.GMAIL.18.1/18.2 even though that list is off. The cause is that the per-list skip in _gmail_domain_addr checks `if not enable`, but at that point `enable` is the attribute name string pulled from settings_list, which is always truthy, so the skip never runs. I changed it to look the attribute up on the override with `override.get(enable)`, which matches what the method docstring says should happen.

I added two unit tests in test_gmail_rules_parser.py covering a disabled list (no marker emitted) and an enabled list with the same domain (marker still emitted, so real findings are not lost). The full Python unit suite passes locally.