### PR TITLE
Replace accesstoken parameter with automated usemetadataserverauth

### DIFF
--- a/docs/authentication/ServiceAccount.md
+++ b/docs/authentication/ServiceAccount.md
@@ -22,6 +22,12 @@ Only complete this section if not authenticating via [OAuth](OAuth.md). See [Aut
 1. Click on **Assign service accounts**
 1. Enter the service account email address and click **ADD**.
 1. Under Set Conditions, ensure that **Access to all groups** is selected and click **ASSIGN ROLE**
+1. To add a custom role for licensing to your service account, navigate to **Account** -> **Admin Roles** in the Workspace Admin Console
+1. Click **Create new role**
+1. Enter a name such as "License Read" and select **CONTINUE**
+1. Under **Admin Privileges** search for "license" and select **License Read**. Click **CONTINUE** then **CREATE ROLE**
+1. Click on **Assign service accounts**
+1. Enter the service account email address, click **ADD**, and click **ASSIGN ROLE**
 1. Return to https://console.cloud.google.com. Open the menu on the left and click **APIs and Services** -> **Enabled API Services**
 1. On the toolbar, click **+ Enable APIs & Services**
 1. Search for and enable the **Admin SDK API**

--- a/docs/authentication/ServiceAccount.md
+++ b/docs/authentication/ServiceAccount.md
@@ -15,7 +15,7 @@ Only complete this section if not authenticating via [OAuth](OAuth.md). See [Aut
 1. Select **MANAGE DOMAIN WIDE DELEGATION**
 1. Select **Add new**
 1. Enter the `client_id` from the downloaded credentials (also visible after clicking on the created Service account under Details -> Unique ID)
-1. Enter each OAuth scope as listed in [Permissions](../prerequisites/Prerequisites.md#permissions)
+1. Enter each Domain-wide delegation scope as listed in [Permissions](../prerequisites/Prerequisites.md#domain-wide-delegation-scopes) in the OAuth scopes field. (Tip: you can copy and paste the entire block into the field.)
 1. Select **AUTHORIZE**
 1. To add the Groups Reader role to your service account, navigate to **Account** -> **Admin Roles** in the Workspace Admin Console.
 1. Locate and click the Groups Reader role, and then expand the **Admins** section.

--- a/docs/prerequisites/Prerequisites.md
+++ b/docs/prerequisites/Prerequisites.md
@@ -2,9 +2,10 @@
 
 ## Permissions
 
-ScubaGoggles requires the users to have Super Admin role to successfully run the tool.
+### OAuth scopes
 
-The tool uses the following OAUTH API scopes:
+ScubaGoggles requires the user to have Super Admin role to successfully run the tool.
+When authenticating interactively via OAuth, you will be prompted to consent to the following scopes:
 
 ```
 https://www.googleapis.com/auth/admin.reports.audit.readonly,
@@ -20,8 +21,21 @@ https://www.googleapis.com/auth/apps.licensing
 https://www.googleapis.com/auth/apps.groups.settings
 ```
 
-When running ScubaGoggles for the first time you will be prompted to consent to
-these API scopes.
+### Domain-wide delegation scopes
+
+When authenticating via a service account, authorize the following scopes under domain-wide delegation:
+
+```
+https://www.googleapis.com/auth/admin.reports.audit.readonly,
+https://www.googleapis.com/auth/admin.directory.domain.readonly,
+https://www.googleapis.com/auth/admin.directory.group.readonly,
+https://www.googleapis.com/auth/admin.directory.orgunit.readonly,
+https://www.googleapis.com/auth/admin.directory.user.readonly,
+https://www.googleapis.com/auth/admin.directory.rolemanagement.readonly,
+https://www.googleapis.com/auth/admin.directory.customer.readonly,
+https://www.googleapis.com/auth/cloud-identity.policies.readonly,
+https://www.googleapis.com/auth/cloud-identity.inboundsso.readonly
+```
 
 ## Google Cloud APIs
 

--- a/docs/usage/Parameters.md
+++ b/docs/usage/Parameters.md
@@ -43,22 +43,22 @@ Here is an example using `-c or --credentials`:
 scubagoggles gws --credentials C:\users\johndoe\Documents\scuba\credentials.json
 ```
 
-## Access Token
+## Metadata Server Authentication
 
-**--accesstoken** string to be used in lieu of a credentials file. If provided, will take precendence over the credentials file. Advanced option; using a credentials file is the recommended authentication method.
+**--usemetadataserverauth** If set, will use the Metadata Server provided in Google Compute Engine (GCE) environments for authentication. The service account associated with the GCE service must have the "iam.serviceAccountTokenCreator" role in addition to other ScubaGoggles roles. Advanced option; using a credentials file is the recommended authentication method.
 
-| Parameter   | Value  |
-|-------------|--------|
-| Optional    | Yes    |
-| Datatype    | String |
-| Default     | n/a    |
-| Config File | Yes    |
+| Parameter   | Value   |
+|-------------|---------|
+| Optional    | Yes     |
+| Datatype    | Boolean |
+| Default     | False  |
+| Config File | Yes     |
 
-Here is an example using `--accesstoken`:
+Here is an example using `--usemetadataserverauth`:
 
 ```powershell
 # identify access token to be used in lieu of a credentials file
-scubagoggles gws --accesstoken <access-token>
+scubagoggles gws ----usemetadataserverauth
 ```
 
 ## Baselines
@@ -399,7 +399,7 @@ for the list of applicable policies.
 |-------------|---------|
 | Optional    | Yes     |
 | Datatype    | Boolean |
-| Default     | $false  |
+| Default     | False  |
 | Config File | Yes     |
 
 Here is an example using `--skipdoh`:

--- a/scubagoggles/Testing/Unit/Python/provider/test_provider.py
+++ b/scubagoggles/Testing/Unit/Python/provider/test_provider.py
@@ -94,7 +94,7 @@ class TestProvider:
         defaults = {
             "customer_id": "test_customer",
             "credentials_file": "credentials.json",
-            "access_token": "token",
+            "metadata_auth": False,
             "svc_account_email": "svc@test.com",
         }
         params = {**defaults, **overrides}

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -7,13 +7,15 @@ This module uses a local credential.json file to authenticate to a GWS org
 import json
 from pathlib import Path
 
+from google.auth import iam
 from google.auth.credentials import TokenState
 from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google.oauth2.service_account import Credentials as SvcCredentials
+from google.auth.compute_engine import Credentials as GceCredentials
 from google_auth_oauthlib.flow import InstalledAppFlow
-from scubagoggles.scuba_constants import DWD_SCOPES, OAUTH_SCOPES, DASA_SCOPES
+from scubagoggles.scuba_constants import DWD_SCOPES, OAUTH_SCOPES, DASA_SCOPES, METADATA_AUTH_SCOPES
 
 # The class is worth it just for the encapsulation.  It allows the potential
 # of credential refresh multiple times, which may be beneficial during a
@@ -26,7 +28,7 @@ class GwsAuth:
     """Generates an Oauth token for accessing Google's APIs
     """
 
-    def __init__(self, credentials_path: Path, access_token: str = None,
+    def __init__(self, credentials_path: Path, metadata_auth: bool = False,
                  svc_account_email: str = None):
         """GwsAuth class initialization.
 
@@ -36,16 +38,18 @@ class GwsAuth:
 
         :param credentials_path: path to the Google JSON-format
             credentials file.
-        :param access_token: (optional) access token string that will be used
-            instead of the credentials file.
+        :param metadata_auth: (optional) if set, will attempt to authenticate
+            via metadata server provided in Google Compute Engine (GCE) services.
+            Service account must have `iam.serviceAccountTokenCreator` permission.
         :param svc_account_email: (optional) email address for the service
             account.
         """
 
         self._svc_account_email = svc_account_email
+        self._metadata_auth = metadata_auth
 
-        if access_token is not None:
-            self._token = Credentials(token=access_token, scopes=OAUTH_SCOPES)
+        if metadata_auth:
+            self._token = GceCredentials(scopes=METADATA_AUTH_SCOPES)
             return
 
         credentials_path = Path(credentials_path)
@@ -95,8 +99,24 @@ class GwsAuth:
         :return: valid Google credentials
         """
 
-        if not self._svc_account_email:
+        if self._metadata_auth or not self._svc_account_email:
             self._refresh_token()
+        if self._metadata_auth:
+            # if using metadata server auth we need a new credential with impersonation
+            # See GCE access to Google AdminSDK example at
+            # https://github.com/GoogleCloudPlatform/professional-services
+            signer = iam.Signer(Request(), self._token, self._token.service_account_email)
+            updated_credentials = SvcCredentials(
+                signer,
+                self._token.service_account_email,
+                "https://accounts.google.com/o/oauth2/token",
+                scopes=DWD_SCOPES,
+                subject=self._svc_account_email,
+            )
+            updated_credentials.refresh(Request())
+            if not updated_credentials.valid:
+                raise Exception(f"Couldn't get valid credentials for {self._svc_account_email}")
+            return updated_credentials
 
         return self._token
 
@@ -115,6 +135,8 @@ class GwsAuth:
                 str(self._credentials_path),
                 scopes=DASA_SCOPES
             )
+        if self._metadata_auth:
+            self._refresh_token()
         return self._token
 
     def _check_scopes(self):
@@ -182,7 +204,8 @@ class GwsAuth:
 
         if self._token.token_state != TokenState.FRESH:
             self._token.refresh(Request())
-            self._save_token()
+            if not self._metadata_auth:
+                self._save_token()
 
     def _save_token(self):
         """Writes the Google credentials to the token JSON file.

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -121,7 +121,7 @@ class GwsAuth:
         return self._token
 
     @property
-    def groups_credentials(self):
+    def dasa_credentials(self):
         """Returns credentials for the Groups Settings API.
 
         When using a service account, returns credentials where the service

--- a/scubagoggles/main.py
+++ b/scubagoggles/main.py
@@ -77,14 +77,13 @@ def get_gws_args(parser: argparse.ArgumentParser, user_config: UserConfig):
                         choices=('true', 'false'),
                         help=argparse.SUPPRESS)
 
-    help_msg = ('Access token string to be used in lieu of a credentials file. '
-                'If provided, will take precendence over the credentials file. '
-                'Advanced option; using a credentials file is the recommended '
-                'authentication method.')
-    parser.add_argument('--accesstoken',
-                        metavar='<access-token>',
-                        type=str,
-                        default=None,
+    help_msg = ('If set, will use the Metadata Server provided in Google Compute Engine '
+                '(GCE) environments for authentication. '
+                'The service account associated with the GCE service must have the '
+                '"iam.serviceAccountTokenCreator" role in addition to other ScubaGoggles roles. '
+                'Advanced option; using a credentials file is recommended.')
+    parser.add_argument('--usemetadataserverauth',
+                        action='store_true',
                         help=help_msg)
 
     help_msg = ('A list of one or more abbreviated GWS baseline names that the '

--- a/scubagoggles/orchestrator.py
+++ b/scubagoggles/orchestrator.py
@@ -197,7 +197,7 @@ class Orchestrator:
         (baselines,
          customerid,
          credentials,
-         accesstoken,
+         usemetadataserverauth,
          subjectemail,
          preferreddnsresolvers,
          skipdoh,
@@ -210,7 +210,7 @@ class Orchestrator:
          sitesexclusions) = itemgetter('baselines',
                                        'customerid',
                                        'credentials',
-                                       'accesstoken',
+                                       'usemetadataserverauth',
                                        'subjectemail',
                                        'preferreddnsresolvers',
                                        'skipdoh',
@@ -224,7 +224,7 @@ class Orchestrator:
 
         with Provider(customerid,
                       credentials,
-                      access_token=accesstoken,
+                      metadata_auth=usemetadataserverauth,
                       svc_account_email=subjectemail,
                       dns_resolvers=preferreddnsresolvers,
                       doh_servers=self.args_dict['preferreddohservers'],
@@ -946,7 +946,7 @@ class Orchestrator:
             args.outputpath = Path(args.outputpath)
         args.outputpath = args.outputpath.resolve()
 
-        if args.accesstoken is None:
+        if not args.usemetadataserverauth:
             if args.credentials is None:
                 raise UserRuntimeError('Google credentials file path not provided. '
                     'Either save the credentials path using the ScubaGoggles setup '
@@ -965,7 +965,7 @@ class Orchestrator:
             raise UserRuntimeError(f'? "{args.opapath}" - OPA executable '
                                    f'missing - {see_docs}') from fnf
 
-        if args.accesstoken is None and not args.credentials.exists():
+        if not args.usemetadataserverauth and not args.credentials.exists():
             raise UserRuntimeError(f'? "{args.credentials}" - Google '
                                    f'credentials file missing - {see_docs}')
 

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -289,7 +289,7 @@ class Provider:
         self._services['groups'] = build('groupssettings',
                                          'v1',
                                          cache_discovery = False,
-                                         credentials = self._gws_auth.groups_credentials)
+                                         credentials = self._gws_auth.dasa_credentials)
 
     def _cached_list(
         self,
@@ -1011,7 +1011,7 @@ class Provider:
         try:
             licensing_service = build('licensing', 'v1',
                                       cache_discovery=False,
-                                      credentials=self._credentials,
+                                      credentials=self._gws_auth.dasa_credentials,
                                       num_retries=0)
 
             any_success = False

--- a/scubagoggles/provider.py
+++ b/scubagoggles/provider.py
@@ -192,7 +192,7 @@ class Provider:
                  customer_id: str,
                  credentials_file: Path,
                  *, # everything after this is keyword-only
-                 access_token: str = None,
+                 metadata_auth: bool = False,
                  svc_account_email: str = None,
                  dns_resolvers: list = None,
                  doh_servers: list = None,
@@ -203,8 +203,8 @@ class Provider:
         :param customer_id: the ID of the customer to run against.
         :param credentials_file: file specification of Google JSON-format
             credentials.
-        :param access_token: (optional) access token string that will be used
-            instead of the credentials file.
+        :param metadata_auth: (optional) if set will use GCE metadata server
+            for authentication
         :param svc_account_email: (optional) email address for the service
             account.
         :param dns_resolvers: (optional) list of DNS resolvers that should be
@@ -215,7 +215,7 @@ class Provider:
             retried over DoH.
         """
 
-        self._gws_auth = GwsAuth(credentials_file, access_token, svc_account_email)
+        self._gws_auth = GwsAuth(credentials_file, metadata_auth, svc_account_email)
         self._credentials = self._gws_auth.credentials
         self._services = {}
         self._customer_id = customer_id

--- a/scubagoggles/sample-config-files/full_config.yaml
+++ b/scubagoggles/sample-config-files/full_config.yaml
@@ -32,10 +32,10 @@ baselines:
 # Required unless the credentials path has been saved using the ScubaGoggles setup utility or an access token is provided.
 # credentials: C:\users\johndoe\Documents\scuba\credentials.json
 
-# Access Token: This field is used to authenticate via access token string to be used in lieu of a credentials file. 
-# If provided, will take precendence over the credentials file. 
+# Metadata Server Authentication: If set, will use the Metadata Server provided in Google Compute Engine (GCE) environments for authentication. 
+# The service account associated with the GCE service must have the "iam.serviceAccountTokenCreator" role in addition to other ScubaGoggles roles. 
 # Advanced option; using a credentials file is the recommended authentication method.
-# accesstoken: <access-token>
+# usemetadataserverauth: false
 
 # Output Path: -o or --outputpath is the folder path where both the output JSON & HTML report will be created. 
 # The folder will be created if it does not exist.

--- a/scubagoggles/scuba_constants.py
+++ b/scubagoggles/scuba_constants.py
@@ -99,3 +99,5 @@ def scopes_for(flow: AuthFlow) -> tuple:
 DWD_SCOPES = scopes_for(AuthFlow.DWD)
 OAUTH_SCOPES = scopes_for(AuthFlow.OAUTH)
 DASA_SCOPES = scopes_for(AuthFlow.DASA)
+# Matches DASA plus one scope to allow creating new tokens
+METADATA_AUTH_SCOPES = (*scopes_for(AuthFlow.DASA), f'{BASE_AUTH_URL}/cloud-platform')

--- a/scubagoggles/ui/scubaconfigapp.py
+++ b/scubagoggles/ui/scubaconfigapp.py
@@ -406,7 +406,7 @@ class ScubaConfigApp:
                 'outputregofilename': '',
                 'outputreportfilename': '',
                 'numberofuuidcharacterstotruncate': 18,
-                'accesstoken': '',
+                'usemetadataserverauth': False,
             }
 
         if 'ui_show_help' not in st.session_state:
@@ -687,7 +687,7 @@ class ScubaConfigApp:
             'outjsonfilename', 'regopath', 'documentpath',
             'outputproviderfilename', 'outputactionplanfilename',
             'outputregofilename', 'outputreportfilename',
-            'accesstoken',
+            'usemetadataserverauth',
         ):
             if key in config:
                 data[key] = str(config[key])
@@ -1985,7 +1985,6 @@ class ScubaConfigApp:
 
         st.markdown('</div>', unsafe_allow_html=True)
 
-
     def _render_sites_exclusions_section(self):
         """Render Sites exclusions section within the Exclusions tab."""
         st.markdown('<div class="section-container">', unsafe_allow_html=True)
@@ -2089,7 +2088,6 @@ class ScubaConfigApp:
             st.info("ℹ️ No Sites exclusion configured")
 
         st.markdown('</div>', unsafe_allow_html=True)
-
 
     @staticmethod
     def _on_advanced_field_change():
@@ -2237,18 +2235,14 @@ class ScubaConfigApp:
         # --- Access token ---
         st.markdown("### Authentication")
 
-        data['accesstoken'] = st.text_input(
-            "Access Token",
-            value=data.get('accesstoken', ''),
-            placeholder="(optional — credentials file is recommended)",
-            help=(
-                "OAuth access token to use instead of a credentials file. "
-                "If provided, takes precedence over the credentials file. "
-                "Using a credentials file is the recommended authentication method."
-            ),
-            type="password",
-            key="adv_accesstoken",
-            on_change=_on_change,
+        data["usemetadataserverauth"] = st.checkbox(
+            "Metadata Server Authentication",
+            value=data.get("usemetadataserverauth", False),
+            help="If set, will use the Metadata Server provided in Google Compute Engine (GCE) environments for "
+            "authentication. The service account associated with the GCE service must have the "
+            "\"iam.serviceAccountTokenCreator\" role in addition to other ScubaGoggles roles. "
+            "Advanced option; using a credentials file is the recommended authentication method.",
+            key="usemetadataserverauth",
         )
 
         st.markdown('</div>', unsafe_allow_html=True)
@@ -2323,7 +2317,7 @@ class ScubaConfigApp:
             'outjsonfilename', 'regopath', 'documentpath',
             'outputproviderfilename', 'outputactionplanfilename',
             'outputregofilename', 'outputreportfilename',
-            'accesstoken',
+            'usemetadataserverauth',
         ):
             if data.get(key):
                 config[key] = data[key]

--- a/scubagoggles/ui/validation.py
+++ b/scubagoggles/ui/validation.py
@@ -56,23 +56,6 @@ class ConfigValidator:
         return error is None, error
 
     @staticmethod
-    def validate_access_token(token: str) -> Tuple[bool, Optional[str]]:
-        """Validate access token format"""
-        if not token:
-            return False, "Access token is required"
-
-        # Basic token format validation.
-        # Google tokens are typically long alphanumeric strings.
-        if len(token) < 50:
-            return False, "Access token appears to be too short"
-
-        # Check for common token patterns
-        if not re.match(r"^[A-Za-z0-9._-]+$", token):
-            return False, "Access token contains invalid characters"
-
-        return True, None
-
-    @staticmethod
     def validate_output_path(output_path: str) -> Tuple[bool, Optional[str]]:
         """Validate output directory path"""
         if not output_path:
@@ -205,18 +188,14 @@ class ConfigValidator:
     ):
         """Validate authentication fields and append any errors."""
         has_creds = config_dict.get("credentials")
-        has_token = config_dict.get("accesstoken")
+        metadata_auth = config_dict.get("usemetadataserverauth")
 
-        if not has_creds and not has_token:
-            errors.append("Either credentials file or access token is required")
+        if not has_creds and not metadata_auth:
+            errors.append("Either credentials file or metadata auth flag is required")
         elif has_creds:
             is_valid, error = ConfigValidator.validate_credentials_file(has_creds)
             if not is_valid:
                 errors.append(f"Credentials validation: {error}")
-        elif has_token:
-            is_valid, error = ConfigValidator.validate_access_token(has_token)
-            if not is_valid:
-                errors.append(f"Access token validation: {error}")
 
     @staticmethod
     def validate_complete_config(


### PR DESCRIPTION
## 🗣 Description ##

This PR replaces the `--accesstoken <token>` paramater with a new flag `--usemetadataserverauth`. 
This new flag instructs ScubaGoggles to authenticate using the metadata server present in Google compute engine instances (see https://docs.cloud.google.com/docs/authentication/application-default-credentials#attached-sa). 

This PR also makes a fix to the new license read scope when using a service account and updates the docs to clarify that you do not need to grant domain-wide delegation for `apps.groups.settings` or `apps.licensing`  when using service account authentication (DASA removes needing this).

### 💭 Motivation and context

Previously, `accesstoken` was added for ScubaConnect to be able to authenticate inside Cloud Run without managing any credential keys.
With the introduction of DASA, this was no longer sufficient as the access token was only for the impersonated domain-wide delegated roles.
While one solution may have been for ScubaConnect to generate two separate access tokens and provide each as parameters, this PR instead moves the logic into ScubaGoggles for a cleaner overall interface and better compatibility for others who want to run ScubaGoggles inside GCP.



<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->


## 🧪 Testing

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Tested via deploying ScubaConnect with this branch and verifying that there were no errors running against test tenants.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
