### PR TITLE
Update password length requirement

### DIFF
--- a/scubagoggles/Testing/Unit/Rego/commoncontrols/commoncontrols_api05_test.rego
+++ b/scubagoggles/Testing/Unit/Rego/commoncontrols/commoncontrols_api05_test.rego
@@ -9,7 +9,7 @@ GoodCaseInputApi05 := {
         "topOU": {
             "security_password": {
                 "allowedStrength": "STRONG",
-                "minimumLength": 15,
+                "minimumLength": 16,
                 "maximumLength": 100,
                 "enforceRequirementsAtLogin": true,
                 "allowReuse": false,
@@ -45,7 +45,7 @@ BadCaseInputApi05a := {
         "topOU": {
             "security_password": {
                 "allowedStrength": "STRONG",
-                "minimumLength": 15,
+                "minimumLength": 16,
                 "maximumLength": 100,
                 "enforceRequirementsAtLogin": true,
                 "allowReuse": false,

--- a/scubagoggles/rego/Commoncontrols.rego
+++ b/scubagoggles/rego/Commoncontrols.rego
@@ -804,7 +804,7 @@ if {
 
 CommonControlsId5_3 := utils.PolicyIdWithSuffix("GWS.COMMONCONTROLS.5.3")
 
-SuggestedPasswordLength := 15
+SuggestedPasswordLength := 16
 
 FormatMessage5_3 := "Minimum password length: %d, recommended is at least %d"
 NonComplianceMessage5_3(Value) := sprintf(FormatMessage5_3,


### PR DESCRIPTION
## 🗣 Description ##
Update the password length requirement for GWS.COMMONCONTROLS.5.3v1 from 15 to 16 characters (in the Rego; baseline change previously made).

### 💭 Motivation and context
PR https://github.com/cisagov/ScubaGoggles/pull/1105 updated the password length for GWS.COMMONCONTROLS.5.3v1 from 15 character to 16. That PR only made the baseline change; this PR has the corresponding Rego change.


## 🧪 Testing
- Manually tested
- Updated unit tests

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
