### PR TITLE
Add GWS.MEET.6.3v1 policy

### DIFF
--- a/scubagoggles/baselines/meet.md
+++ b/scubagoggles/baselines/meet.md
@@ -312,10 +312,12 @@ Screenshots of presented content SHALL only captured in notes when recording is 
 
 [![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)
 
-- _Rationale:_ Meeting notes may contain sensitive information that should not be shared outside of the organization. Setting a secure default sharing level reduces the risk of inadvertent meeting note sharing.
+- _Rationale:_ Screenshots of presented content may contain sensitive information. Restricting screenshot capture to meetings where recording is enabled helps ensure visual content is only retained when the meeting host has intentionally elected to record the meeting.
+
 - _Last modified:_ August 2026
-- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ AC-3, SC-7(10)
 - MITRE ATT&CK TTP Mapping
+  - [T1113: Screen Capture](https://attack.mitre.org/techniques/T1113/)
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
   - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
 

--- a/scubagoggles/baselines/meet.md
+++ b/scubagoggles/baselines/meet.md
@@ -307,6 +307,17 @@ Default sharing setting for Google AI notes SHALL be restricted to "Guests in yo
   - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
   - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
 
+#### GWS.MEET.6.3v1
+Screenshots of presented content SHALL only captured in notes when recording is enabled.
+
+[![Manual](https://img.shields.io/badge/Manual-046B9A)](#gwscommoncontrols83v06-instructions)
+
+- _Rationale:_ Meeting notes may contain sensitive information that should not be shared outside of the organization. Setting a secure default sharing level reduces the risk of inadvertent meeting note sharing.
+- _Last modified:_ August 2026
+- _NIST SP 800-53 Rev. 5 FedRAMP High Baseline Mapping:_ SC-7(10)
+- MITRE ATT&CK TTP Mapping
+  - [T1530: Data from Cloud Storage](https://attack.mitre.org/techniques/T1530/)
+  - [T1567:002: Exfiltration Over Web Service: Exfiltration to Cloud Storage](https://attack.mitre.org/techniques/T1567/002/)
 
 ### Resources
 - [Take notes for me in Google Meet](https://support.google.com/meet/answer/14754931)
@@ -330,4 +341,12 @@ Default sharing setting for Google AI notes SHALL be restricted to "Guests in yo
 3.  Click **Gemini Settings**.
 4.  Click **Google AI notes sharing**.
 5.  Ensure **Default sharing setting for Google AI notes** is set to "The hosts and co-hosts" or "Invited Guests in your Organization".
+6.  Click **Save**.
+
+#### GWS.MEET.6.3v1 Instructions
+1.  Sign in to the [Google Admin Console](https://admin.google.com).
+2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
+3.  Click **Gemini Settings**.
+4.  Click **Visual content in notes**.
+5.  Ensure **Select when the visual notes feature is enabled** is set to "Only allow screenshots of presented content to be captured in notes when recording is enabled".
 6.  Click **Save**.

--- a/scubagoggles/baselines/meet.md
+++ b/scubagoggles/baselines/meet.md
@@ -333,7 +333,7 @@ Screenshots of presented content SHALL only captured in notes when recording is 
 1.  Sign in to the [Google Admin Console](https://admin.google.com).
 2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
 3.  Click **Gemini Settings**.
-4.  Click **Google AI notes sharing**.
+4.  Click **Gemini notes sharing**.
 5.  Ensure **Allow hosts to change who notes are shared to** is unselected.
 6.  Click **Save**.
 
@@ -341,8 +341,8 @@ Screenshots of presented content SHALL only captured in notes when recording is 
 1.  Sign in to the [Google Admin Console](https://admin.google.com).
 2.  Select **Menu** -> **Apps** -> **Google Workspace** -> **Google Meet**.
 3.  Click **Gemini Settings**.
-4.  Click **Google AI notes sharing**.
-5.  Ensure **Default sharing setting for Google AI notes** is set to "The hosts and co-hosts" or "Invited Guests in your Organization".
+4.  Click **Gemini notes sharing**.
+5.  Ensure **Default sharing setting for Gemini notes** is set to "The hosts and co-hosts" or "Invited guests in your organization".
 6.  Click **Save**.
 
 #### GWS.MEET.6.3v1 Instructions

--- a/scubagoggles/rego/Meet.rego
+++ b/scubagoggles/rego/Meet.rego
@@ -396,3 +396,21 @@ if {
     Status := (false in Conditions) == false
 }
 #--
+
+#
+# Baseline GWS.MEET.6.3
+#--
+
+MeetId6_3:= utils.PolicyIdWithSuffix("GWS.MEET.6.3")
+
+tests contains {
+    "PolicyId": MeetId6_3,
+    "Prerequisites": [],
+    "Criticality": "Shall/Not-Implemented",
+    "ReportDetails": "Currently not able to be tested automatically; please manually check.",
+    "ActualValue": "",
+    "RequirementMet": false,
+    "NoSuchEvent": false
+}
+
+#--


### PR DESCRIPTION
## 🗣 Description ##

Updated MEET baseline to include GWS.MEET.6.3v1. Policy is a manual check as the Google Policy API does not support this setting. Added NIST 800-53 and MITRE ATT&CK mappings.

### 💭 Motivation and context

Closes #1135 

## 🧪 Testing

Review the GWS.MEET.6.3v1 policy, implementation steps and NIST 800-53 and MITRE ATT&CK mappings.
Run ScubaGoggles and confirm that GWS.MEET.6.3 appears, is a manual check and has a criticality of Shall/Not-Implemented.

## ✅ Pre-approval checklist ##

<!-- Please read and check the boxes below as affirmation that this PR meets the requirements listed -->

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [X] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels have been added.
- [X] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
