### PR TITLE
Fix interactive OAuth crash in environments without a browser

### DIFF
--- a/scubagoggles/Testing/Unit/Python/test_auth.py
+++ b/scubagoggles/Testing/Unit/Python/test_auth.py
@@ -5,6 +5,7 @@ following the ScubaGoggles testing framework patterns.
 """
 
 import json
+import webbrowser
 from pathlib import Path
 
 import pytest
@@ -125,6 +126,7 @@ class TestGwsAuth:
             InstalledAppFlow, 'from_client_secrets_file',
             return_value=mock_flow
         )
+        mocker.patch('scubagoggles.auth.webbrowser.get')
 
         auth = GwsAuth(credentials_file)
 
@@ -132,7 +134,33 @@ class TestGwsAuth:
             str(credentials_file), OAUTH_SCOPES
         )
         mock_flow.run_local_server.assert_called_once_with(
-            timeout_seconds=300, prompt='consent'
+            open_browser=True, timeout_seconds=300, prompt='consent'
+        )
+        assert auth.credentials is mock_fresh_credentials
+
+    def test_init_oauth_flow_without_browser(self, mocker,
+                                             credentials_file,
+                                             mock_fresh_credentials):
+
+        """Verify the OAuth flow runs without opening a browser when no
+        runnable browser is available (e.g., inside a container).
+        """
+
+        mock_flow = mocker.Mock()
+        mock_flow.run_local_server.return_value = mock_fresh_credentials
+
+        mocker.patch.object(
+            InstalledAppFlow, 'from_client_secrets_file',
+            return_value=mock_flow
+        )
+        mocker.patch('scubagoggles.auth.webbrowser.get',
+                     side_effect=webbrowser.Error('could not locate '
+                                                  'runnable browser'))
+
+        auth = GwsAuth(credentials_file)
+
+        mock_flow.run_local_server.assert_called_once_with(
+            open_browser=False, timeout_seconds=300, prompt='consent'
         )
         assert auth.credentials is mock_fresh_credentials
 

--- a/scubagoggles/auth.py
+++ b/scubagoggles/auth.py
@@ -5,6 +5,7 @@ This module uses a local credential.json file to authenticate to a GWS org
 """
 
 import json
+import webbrowser
 from pathlib import Path
 
 from google.auth import iam
@@ -74,17 +75,25 @@ class GwsAuth:
         if self._token:
             return
 
-        # There is no existing token file, so the user will have to authenticate
-        # using a browser on the current system.  There doesn't seem to be an
-        # alternative for users without access to a browser (there was a
-        # run_console() method that was removed in a prior release that may
-        # have worked when no browser was available).
+        # There is no existing token file, so the user will have to
+        # authenticate using a browser.  On systems without a runnable
+        # browser (e.g., inside a container), the flow is told not to open
+        # one because attempting to do so raises webbrowser.Error.  The
+        # flow prints the authorization URL either way, so the user can
+        # open it in a browser that can reach this system's redirect port.
         credentials_file = str(self._credentials_path)
         flow = InstalledAppFlow.from_client_secrets_file(credentials_file,
                                                          OAUTH_SCOPES)
 
         try:
+            webbrowser.get()
+            open_browser = True
+        except webbrowser.Error:
+            open_browser = False
+
+        try:
             self._token = flow.run_local_server(
+                open_browser=open_browser,
                 timeout_seconds=300, prompt='consent')
         except AttributeError as ae:
             raise RuntimeError('Google authorization timeout') from ae


### PR DESCRIPTION
## 🗣 Description ##

`GwsAuth` now checks for a runnable browser before starting the OAuth flow and passes `open_browser=False` to `flow.run_local_server()` when none is found. The flow prints the authorization URL either way, so instead of crashing the run waits for the user to open the link. Also updated the stale code comment that claimed there is no alternative for browserless users.

Detection is based on `webbrowser.get()` raising `webbrowser.Error`, which is the exact failure in the reported traceback. A container that has a browser entry (e.g. a stub `xdg-open`) but no display is not detected and will still try to open a browser.

### 💭 Motivation and context

Running the OAuth workflow inside a container kills the run with `webbrowser.Error: could not locate runnable browser` before authentication can complete. Resolves #1161.

Note the OAuth redirect still targets localhost, so completing the flow from Docker needs host networking or a published port. The printed URL makes that possible; this change does not add a device flow.

## 🧪 Testing

- Reproduced the reported traceback on main by clearing the `webbrowser` registry and instantiating `GwsAuth`; identical `flow.py ... webbrowser.Error` failure. After the change the same setup prints the authorization URL and blocks on the redirect listener.
- New unit test `test_init_oauth_flow_without_browser` covers the no-browser path; the existing flow test now asserts `open_browser=True`.
- `python -m pytest ./scubagoggles/Testing/Unit/Python`: 565 passed.
- `pylint` with the CI invocation: 9.97/10 (repo baseline; both changed files 10.00/10).
- Verified against google_auth_oauthlib 1.4.0 (repo floor is >=1.2.1; `open_browser` exists in both).

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [ ] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
