### PR TITLE
Add CI pipeline badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![GitHub Release][github-release-img]][release]
 [![PyPI - Version][pypi-version-img]][pypi]
+[![CI Pipeline][ci-pipeline-img]][ci-pipeline]
 [![GitHub Downloads][github-downloads-img]][release]
 [![PyPI Downloads][pypi-downloads-img]][pypi]
 [![GitHub License][github-license-img]][license]
@@ -70,6 +71,8 @@ submitted with an alternate compatible license. If accepted, those
 contributions will be listed herein with the appropriate license.
 
 [release]: https://github.com/cisagov/ScubaGoggles/releases
+[ci-pipeline]: https://github.com/cisagov/ScubaGoggles/actions/workflows/run_pipeline.yml
+[ci-pipeline-img]: https://img.shields.io/github/actions/workflow/status/cisagov/ScubaGoggles/run_pipeline.yml?branch=main&label=CI%20Pipeline
 [github-release-img]: https://img.shields.io/github/v/release/cisagov/ScubaGoggles?label=GitHub&logo=github
 [github-downloads-img]: https://img.shields.io/github/downloads/cisagov/ScubaGoggles/total?label=GitHub%20downloads
 [pypi]: https://pypi.org/project/scubagoggles/


### PR DESCRIPTION
## 🗣 Description ##

Adds a CI Pipeline status badge for `run_pipeline.yml` to the README, using the same shields.io reference-link style as the existing badges. Placed after the release/version badges, mirroring ScubaGear's ordering.

### 💭 Motivation and context

The README shows release, downloads, and license badges but nothing about CI health. Resolves #1153.

## 🧪 Testing

Verified both URLs resolve (badge renders "passing", link opens the Actions page for run_pipeline.yml). The badge URL pins `branch=main` so PR runs do not affect it.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [x] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [x] All relevant type-of-change labels have been added.
- [x] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [ ] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [x] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [x] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
