### PR TITLE
Fix CHAT.5.2 Bug

### DIFF
--- a/scubagoggles/rego/Chat.rego
+++ b/scubagoggles/rego/Chat.rego
@@ -445,7 +445,11 @@ NonCompliantOUs5_2 contains {
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
-    EnabledCats := {trim(cat, " []\n") | some cat in split(LastEvent.NewValue, ",")}
+    EnabledCats := {
+        trim(regex.replace(cat, `\s+`, " "), " []")
+        |
+        some cat in split(LastEvent.NewValue, ",")
+    }
     MissingCats := AllReportingCategories - EnabledCats
     count(MissingCats) > 0
 }
@@ -485,7 +489,11 @@ NonCompliantOUs5_2 contains {
     count(Events) > 0
     LastEvent := utils.GetLastEvent(Events)
     LastEvent.NewValue != "DELETE_APPLICATION_SETTING"
-    EnabledCats := {trim(cat, " []\n") | some cat in split(LastEvent.NewValue, ",")}
+    EnabledCats := {
+        trim(regex.replace(cat, `\s+`, " "), " []")
+        |
+        some cat in split(LastEvent.NewValue, ",")
+    }
     MissingCats := AllReportingCategories - EnabledCats
     count(MissingCats) > 0
 }


### PR DESCRIPTION
## 🗣 Description ##

Modified Chat.5.2 Rego code to remove all whitespace, not just trailing or leading whitespace.

### 💭 Motivation and context

Closes #1148 

## 🧪 Testing

In the Google Admin Console
Select Menu -> Apps -> Google Workspace -> Google Chat.
Click Manage content reporting then Content reporting.
Ensure all checkboxes under Reporting categories are selected.
Run ScubaGoggles and confirm that CHAT.5.2 passes when all reporting categories are checked.

Remove some checkboxes, confirm that CHAT.5.2 accurate gives a warning and lists the unchecked reporting categories.

## ✅ Pre-approval checklist ##

- [X] This PR has an informative and human-readable title.
- [X] Changes are limited to a single goal - *eschew scope creep!*
- [X] If applicable, *All* future TODOs are captured in issues, which are referenced in the PR description.
- [X] The relevant issues PR resolves are linked preferably via [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword).
- [X] All relevant type-of-change labels have been added.
- [X] I have read and agree to the [CONTRIBUTING.md](https://github.com/cisagov/ScubaGoggles/blob/main/CONTRIBUTING.md) document.
- [X] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [X] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [X] Tests have been added and/or modified to cover the changes in this PR.
- [X] All new and existing tests pass.

## ✅ Pre-merge Checklist

- [ ] This PR has been smoke tested to ensure main is in a functional state when this PR is merged.
- [ ] Squash all commits into one PR level commit using the `Squash and merge` button.

## ✅ Post-merge Checklist

- [ ] Delete the branch to clean up.
- [ ] Close issues resolved by this PR if the [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) did not activate.
