### PR TITLE
Treat DLP match counts as optional in a rule condition

### DIFF
--- a/scubagoggles/Testing/Unit/Python/parsers/test_dlp_rules_parser.py
+++ b/scubagoggles/Testing/Unit/Python/parsers/test_dlp_rules_parser.py
@@ -1,0 +1,69 @@
+"""Tests for the DlpRulesParser class.
+"""
+
+import pytest
+
+from scubagoggles.parsers.dlp_rules_parser import DlpRulesParser
+
+# pylint: disable=too-few-public-methods
+
+
+def _rule(detector: str, likelihood: str, counts: str = '') -> dict:
+
+    """Builds a rule carrying a single DLP content condition, in the form
+    Google returns from the Policy API.
+    """
+
+    condition = (f'all_content.matches_dlp_detector("{detector}", '
+                 f'google.privacy.dlp.v2.Likelihood.{likelihood}{counts}')
+    condition += ')'
+
+    return {'condition': {'contentCondition': condition}}
+
+
+class TestDlpRulesParser:
+
+    """This class contains unit tests for the DlpRulesParser class.
+    """
+
+    # The test module needs to access "internal" methods.
+    # pylint: disable=protected-access
+
+    _both_counts = ', {minimum_match_count: 1, minimum_unique_match_count: 1}'
+
+    @pytest.mark.parametrize('counts',
+                             [_both_counts,
+                              '',
+                              ', {minimum_match_count: 1}',
+                              ', {minimum_unique_match_count: 1}'],
+                             ids = ['both counts',
+                                    'no counts',
+                                    'minimum only',
+                                    'unique only'])
+    def test_condition_counts_optional(self, counts):
+
+        """A condition may leave out either match count, or both.  Google
+        omits them for rules whose action has nowhere to set one, and the
+        term then triggers on a single match, which meets the baseline.
+        """
+
+        rule = _rule('CREDIT_CARD_NUMBER', 'LIKELY', counts)
+
+        assert (DlpRulesParser._check_condition(rule)
+                == {'CREDIT_CARD_NUMBER'})
+
+    @pytest.mark.parametrize(
+        'detector,likelihood,counts',
+        [('CREDIT_CARD_NUMBER', 'LIKELY',
+          ', {minimum_match_count: 5, minimum_unique_match_count: 1}'),
+         ('CREDIT_CARD_NUMBER', 'POSSIBLE', _both_counts),
+         ('EMAIL_ADDRESS', 'LIKELY', _both_counts)],
+        ids = ['count above one', 'likelihood too low', 'detector not required'])
+    def test_condition_rejected(self, detector, likelihood, counts):
+
+        """A term that does not meet the baseline contributes no detector.
+        """
+
+        rule = _rule(detector, likelihood, counts)
+
+        assert not DlpRulesParser._check_condition(rule)

--- a/scubagoggles/parsers/dlp_rules_parser.py
+++ b/scubagoggles/parsers/dlp_rules_parser.py
@@ -222,7 +222,7 @@ class DlpRulesParser:
     def _check_arguments(cls,
                          detector: str,
                          likelihood: Likelihood,
-                         match_counts: dict) -> tuple:
+                         match_counts: dict = None) -> tuple:
 
         """Returns a tuple which includes whether the arguments for the DLP
         condition match the expected values, and the detector name if the
@@ -237,11 +237,22 @@ class DlpRulesParser:
         # The arguments are correct if the likelihood is at least "likely"
         # or "greater" (e.g., "very likely"), and the minimum match counts
         # are 1.
+        #
+        # The match counts are optional in the condition.  Google omits them
+        # for rules whose action has nowhere to set one, such as applying a
+        # label, and it omits either count individually.  A term that sets no
+        # threshold triggers on a single match, which is what the baseline
+        # asks for, so an absent count satisfies the requirement rather than
+        # failing it.  Reading them positionally used to raise a TypeError
+        # that ended the whole scan.
+
+        match_counts = match_counts or {}
 
         arguments_ok = (detector in cls._minimum_detectors
                         and likelihood >= Likelihood.LIKELY
-                        and match_counts['minimum_match_count'] == 1
-                        and match_counts['minimum_unique_match_count'] == 1)
+                        and match_counts.get('minimum_match_count', 1) == 1
+                        and match_counts.get('minimum_unique_match_count',
+                                             1) == 1)
 
         return arguments_ok, detector
 


### PR DESCRIPTION
Closes #1185.

`_check_arguments` takes `match_counts` positionally with no default, and `_check_condition` calls it by evaluating the condition's own argument list. A DLP term that carries no match counts therefore arrives with two arguments instead of three, and the `TypeError` propagates all the way out of `start_automation`, so one such policy ends the entire scan rather than that single rule.

I reproduced it by handing `_check_condition` the two-argument form directly, and got the same line the report shows:

    TypeError: DlpRulesParser._check_arguments() missing 1 required positional argument: 'match_counts'

`match_counts` now defaults to `None`, and the two counts are read with `.get(..., 1)` rather than by subscript. That second part matters as much as the first: the counts are omitted individually as well as together, so a condition carrying only `minimum_match_count` would have raised `KeyError` on the next line even once the `TypeError` was gone.

On the semantics, an absent count is treated as meeting the requirement rather than failing it. A term that sets no threshold triggers on a single match, which is what the baseline asks for when it requires counts of 1, so reading the omission as a failure would report a policy as non-compliant when it is in fact stricter. That is a judgement rather than something the API documents, so if you would rather an unspecified count be treated as unknown and the rule skipped, say so and I will change it.

The new `test_dlp_rules_parser.py` covers the four shapes the condition can take (both counts, neither, and each one alone) and three that should still be rejected: a count above one, a likelihood below `LIKELY`, and a detector outside `_minimum_detectors`. Against the current code three of the seven fail with the `TypeError` above. `pytest` over `Testing/Unit/Python/parsers` and `test_policy_api.py` is 64 passed, 28 subtests passed, and pylint rates both files 10.00/10.