### PR TITLE
Keep user configuration defaults independent between instances

### DIFF
--- a/scubagoggles/Testing/Unit/Python/config/test_config.py
+++ b/scubagoggles/Testing/Unit/Python/config/test_config.py
@@ -118,3 +118,25 @@ class TestUserConfig:
 
         # Verify the error message contains the invalid key
         assert 'invalid_key' in str(exc_info.value)
+
+    @pytest.mark.parametrize('setting', ['output_dir', 'opa_dir', 'credentials_file'])
+    def test_new_configs_do_not_share_settings(self, tmp_path, setting, mocker):
+        """Changing one configuration must not alter other instances or defaults."""
+        mocker.patch.object(UserConfig, '_transition_config_file')
+        first = UserConfig(tmp_path / 'first.yaml')
+        second = UserConfig(tmp_path / 'second.yaml')
+        original_value = getattr(second, setting)
+        custom_value = tmp_path / 'custom'
+
+        setattr(first, setting, custom_value)
+
+        assert getattr(first, setting) == custom_value
+        assert getattr(second, setting) == original_value
+        third = UserConfig(tmp_path / 'third.yaml')
+        assert getattr(third, setting) == original_value
+
+        # Persisting one configuration must not write another instance's values.
+        first.write()
+        second.write()
+        assert getattr(UserConfig(first.config_path), setting) == custom_value
+        assert getattr(UserConfig(second.config_path), setting) == original_value

--- a/scubagoggles/config.py
+++ b/scubagoggles/config.py
@@ -5,6 +5,7 @@ location, and the OPA executable location.
 
 import os
 
+from copy import deepcopy
 from typing import Iterable, Union
 from pathlib import Path
 
@@ -57,7 +58,7 @@ class UserConfig:
             self._validate()
             self._file_exists = True
         else:
-            self._doc = dict(self._defaults)
+            self._doc = deepcopy(self._defaults)
             self._file_exists = False
 
     @property


### PR DESCRIPTION
## Summary

Deep-copy default settings when creating a `UserConfig` without an existing file. Changes to output, OPA or credentials paths now stay within that instance instead of modifying other configurations and the class defaults.

Fixes #1197.

## Testing

- Added three parametrized regression cases covering existing instances, subsequent instances and independent file round-trips. All three fail before the fix.
- Full Python unit suite on Python 3.12: **582 passed, 33 subtests passed**.
- Changed-file Pylint passes with the repository's disabled-check list.
